### PR TITLE
Fix HS_ARCH to deal with the error for make rule

### DIFF
--- a/hotspot/make/Makefile
+++ b/hotspot/make/Makefile
@@ -252,8 +252,13 @@ ifeq ($(HS_ARCH),ppc)
   else
 	@$(ECHO) "No ($(VM_TARGET)) for ppc ARCH_DATA_MODEL=$(ARCH_DATA_MODEL)"
   endif
+else ifeq ($(HS_ARCH),riscv64)
+		$(MKDIR) -p $(OUTPUTDIR)
+		$(CD) $(OUTPUTDIR); \
+			$(MAKE) -f $(ABS_OS_MAKEFILE) \
+				$(MAKE_ARGS) $(VM_TARGET)
 else
-	@$(ECHO) "No ($(VM_TARGET)) for $(HS_ARCH)"
+	@$(ECHO) "No ($(VM_TARGET)) for riscv64 ARCH_DATA_MODEL=$(ARCH_DATA_MODEL)"
 endif
 
 generic_buildzero: $(HOTSPOT_SCRIPT)

--- a/hotspot/make/linux/makefiles/defs.make
+++ b/hotspot/make/linux/makefiles/defs.make
@@ -59,6 +59,15 @@ ifeq ($(findstring true, $(JVM_VARIANT_ZERO) $(JVM_VARIANT_ZEROSHARK)), true)
   ARCH             = zero
 endif
 
+# core
+ifeq ($(ARCH), riscv)
+  ARCH_DATA_MODEL  = 64
+  MAKE_ARGS        += LP64=1
+  PLATFORM         = linux-riscv64
+  VM_PLATFORM      = linux_riscv64
+  HS_ARCH          = riscv64
+endif
+
 # ia64
 ifeq ($(ARCH), ia64)
   ARCH_DATA_MODEL = 64


### PR DESCRIPTION
Added a definition of ARCH in defs.make to solve the problem that HS_ARCH is NULL in Makefile.