### PR TITLE
Fix the note about can not find /../vm

### DIFF
--- a/hotspot/make/linux/platform_riscv64
+++ b/hotspot/make/linux/platform_riscv64
@@ -1,10 +1,10 @@
 os_family = linux
 
-arch = riscv
+arch = riscv64
 
 arch_model = riscv64
 
-os_arch = linux_riscv
+os_arch = linux_riscv64
 
 os_arch_model = linux_riscv64
 


### PR DESCRIPTION
Due to arch and os_arch in Platform_riscv64 needed  to be defined riscv64,linux_riscv64.