### PR TITLE
Fix the error OS_CPU_HEADER_INLINE

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp
@@ -152,6 +152,8 @@ class Bytes: AllStatic {
   static inline void put_Java_u8(address p, u8 x)     { put_native_u8(p, swap_u8(x)); }
 };
 
-#include OS_CPU_HEADER_INLINE(bytes)
+#ifdef TARGET_OS_ARCH_linux_riscv64
+# include "bytes_linux_riscv64.inline.hpp"
+#endif
 
 #endif // CPU_RISCV64_VM_BYTES_RISCV64_HPP

--- a/hotspot/src/cpu/riscv64/vm/copy_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/copy_riscv64.hpp
@@ -30,7 +30,9 @@
 // Inline functions for memory copy and fill.
 
 // Contains inline asm implementations
-#include OS_CPU_HEADER_INLINE(copy)
+#ifdef TARGET_OS_ARCH_linux_riscv64
+# include "copy_linux_riscv64.inline.hpp"
+#endif
 
 
 static void pd_fill_to_words(HeapWord* tohw, size_t count, juint value) {


### PR DESCRIPTION
Use TARGET_OS_ARCH_linux_riscv64 instead of OS_CPU_HEADER_INLINE.