### PR TITLE
Fix interpreter_frame_expression_stack_direction can not be overloaded

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.hpp
@@ -205,6 +205,6 @@
   // deoptimization support
   void interpreter_frame_set_last_sp(intptr_t* ptr_sp);
 
-  static jint interpreter_frame_expression_stack_direction() { return -1; }
+ // static jint interpreter_frame_expression_stack_direction() { return -1; }
 
 #endif // CPU_RISCV64_VM_FRAME_RISCV64_HPP

--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
@@ -254,5 +254,5 @@ inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
     ShouldNotReachHere();
   }
 }
-
+inline jint frame::interpreter_frame_expression_stack_direction() { return -1; }
 #endif // CPU_RISCV64_VM_FRAME_RISCV64_INLINE_HPP


### PR DESCRIPTION
Put inline jint frame::interpreter_frame_expression_stack_direction() in hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp, and delete static jint interpreter_frame_expression_stack_direction() { return -1; } in hotspot/src/cpu/riscv64/vm/frame_riscv64.hpp