### PR TITLE
Add TARGET_ARCH_MODEL_riscv64

### DIFF
--- a/hotspot/src/share/vm/code/vmreg.hpp
+++ b/hotspot/src/share/vm/code/vmreg.hpp
@@ -46,7 +46,8 @@
 # include "adfiles/adGlobals_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/adGlobals_ppc_64.hpp"
-#endif
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/adGlobals_riscv64.hpp"
 #endif
 
 //------------------------------VMReg------------------------------------------

--- a/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
+++ b/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
@@ -42,6 +42,8 @@
 # include "interp_masm_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "interp_masm_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "interp_masm_riscv64.hpp"
 #endif
 
 // This file contains the platform-independent parts

--- a/hotspot/src/share/vm/interpreter/templateTable.hpp
+++ b/hotspot/src/share/vm/interpreter/templateTable.hpp
@@ -40,6 +40,8 @@
 # include "interp_masm_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "interp_masm_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "interp_masm_riscv64.hpp"
 #endif
 
 #ifndef CC_INTERP
@@ -367,7 +369,10 @@ class TemplateTable: AllStatic {
 # include "templateTable_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "templateTable_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "templateTable_riscv64.hpp"
 #endif
+
 
 };
 #endif /* !CC_INTERP */

--- a/hotspot/src/share/vm/opto/c2compiler.cpp
+++ b/hotspot/src/share/vm/opto/c2compiler.cpp
@@ -39,6 +39,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 // register information defined by ADLC

--- a/hotspot/src/share/vm/opto/compile.cpp
+++ b/hotspot/src/share/vm/opto/compile.cpp
@@ -81,6 +81,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 // -------------------- Compile::mach_constant_base_node -----------------------

--- a/hotspot/src/share/vm/opto/lcm.cpp
+++ b/hotspot/src/share/vm/opto/lcm.cpp
@@ -44,6 +44,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 // Optimization - Graph Style

--- a/hotspot/src/share/vm/opto/locknode.hpp
+++ b/hotspot/src/share/vm/opto/locknode.hpp
@@ -42,6 +42,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 //------------------------------BoxLockNode------------------------------------

--- a/hotspot/src/share/vm/opto/matcher.cpp
+++ b/hotspot/src/share/vm/opto/matcher.cpp
@@ -52,6 +52,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 OptoReg::Name OptoReg::c_frame_pointer;

--- a/hotspot/src/share/vm/opto/output.hpp
+++ b/hotspot/src/share/vm/opto/output.hpp
@@ -41,6 +41,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 class Arena;

--- a/hotspot/src/share/vm/opto/regmask.cpp
+++ b/hotspot/src/share/vm/opto/regmask.cpp
@@ -39,6 +39,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 #define RM_SIZE _RM_SIZE /* a constant private to the class RegMask */

--- a/hotspot/src/share/vm/opto/regmask.hpp
+++ b/hotspot/src/share/vm/opto/regmask.hpp
@@ -42,6 +42,8 @@
 # include "adfiles/adGlobals_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/adGlobals_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 // Some fun naming (textual) substitutions:

--- a/hotspot/src/share/vm/opto/runtime.cpp
+++ b/hotspot/src/share/vm/opto/runtime.cpp
@@ -82,6 +82,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 
 

--- a/hotspot/src/share/vm/runtime/deoptimization.cpp
+++ b/hotspot/src/share/vm/runtime/deoptimization.cpp
@@ -86,6 +86,8 @@
 # include "adfiles/ad_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/ad_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 #endif // COMPILER2
 

--- a/hotspot/src/share/vm/runtime/frame.hpp
+++ b/hotspot/src/share/vm/runtime/frame.hpp
@@ -45,6 +45,8 @@
 # include "adfiles/adGlobals_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/adGlobals_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/ad_riscv64.hpp"
 #endif
 #endif // COMPILER2
 #ifdef TARGET_ARCH_zero

--- a/hotspot/src/share/vm/runtime/stubRoutines.hpp
+++ b/hotspot/src/share/vm/runtime/stubRoutines.hpp
@@ -119,6 +119,8 @@ class StubRoutines: AllStatic {
 # include "stubRoutines_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "stubRoutines_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "stubRoutines_riscv64.hpp"
 #endif
 
   static jint    _verify_oop_count;

--- a/hotspot/src/share/vm/runtime/vmStructs.cpp
+++ b/hotspot/src/share/vm/runtime/vmStructs.cpp
@@ -214,6 +214,8 @@
 # include "adfiles/adGlobals_zero.hpp"
 #elif defined TARGET_ARCH_MODEL_ppc_64
 # include "adfiles/adGlobals_ppc_64.hpp"
+#elif defined TARGET_ARCH_MODEL_riscv64
+# include "adfiles/adGlobals_riscv64.hpp"
 #endif
 #endif // COMPILER2
 


### PR DESCRIPTION
Refer to aarch64 to add the TARGET_ARCH_MODEL_riscv64 in rv64.