### PR TITLE
Fix fix_interpreter_frame_bcp_addr

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.hpp
@@ -127,8 +127,8 @@
     interpreter_frame_mirror_offset                  = interpreter_frame_padding_offset - 1,
     interpreter_frame_cache_offset                   = interpreter_frame_mirror_offset - 1,
     interpreter_frame_locals_offset                  = interpreter_frame_cache_offset - 1,
-    interpreter_frame_bcp_offset                     = interpreter_frame_locals_offset - 1,
-    interpreter_frame_initial_sp_offset              = interpreter_frame_bcp_offset - 1,
+    interpreter_frame_bcx_offset                     = interpreter_frame_locals_offset - 1,
+    interpreter_frame_initial_sp_offset              = interpreter_frame_bcx_offset - 1,
 
     interpreter_frame_monitor_block_top_offset       = interpreter_frame_initial_sp_offset,
     interpreter_frame_monitor_block_bottom_offset    = interpreter_frame_initial_sp_offset,

--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
@@ -169,8 +169,8 @@ inline intptr_t* frame::interpreter_frame_last_sp() const {
   return *(intptr_t**)addr_at(interpreter_frame_last_sp_offset);
 }
 
-inline intptr_t* frame::interpreter_frame_bcp_addr() const {
-  return (intptr_t*)addr_at(interpreter_frame_bcp_offset);
+inline intptr_t* frame::interpreter_frame_bcx_addr() const {
+  return (intptr_t*)addr_at(interpreter_frame_bcx_offset);
 }
 
 inline intptr_t* frame::interpreter_frame_mdp_addr() const {

--- a/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.hpp
@@ -67,11 +67,11 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   // Interpreter-specific registers
   void save_bcp() {
-    sd(xbcp, Address(fp, frame::interpreter_frame_bcp_offset * wordSize));
+    sd(xbcp, Address(fp, frame::interpreter_frame_bcx_offset * wordSize));
   }
 
   void restore_bcp() {
-    ld(xbcp, Address(fp, frame::interpreter_frame_bcp_offset * wordSize));
+    ld(xbcp, Address(fp, frame::interpreter_frame_bcx_offset * wordSize));
   }
 
   void restore_locals() {

--- a/hotspot/src/share/vm/runtime/frame.cpp
+++ b/hotspot/src/share/vm/runtime/frame.cpp
@@ -429,6 +429,11 @@ void frame::interpreter_frame_set_method(Method* method) {
   *interpreter_frame_method_addr() = method;
 }
 
+void frame::interpreter_frame_set_mirror(oop mirror) {
+  assert(is_interpreted_frame(), "interpreted frame expected");
+  *interpreter_frame_mirror_addr() = mirror;
+}
+
 void frame::interpreter_frame_set_bcx(intptr_t bcx) {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   if (ProfileInterpreter) {
@@ -495,14 +500,14 @@ void frame::interpreter_frame_set_mdx(intptr_t mdx) {
   *interpreter_frame_mdx_addr() = mdx;
 }
 
-address frame::interpreter_frame_mdp() const {
+intptr_t frame::interpreter_frame_mdp() const {
   assert(ProfileInterpreter, "must be profiling interpreter");
   assert(is_interpreted_frame(), "interpreted frame expected");
   intptr_t bcx = interpreter_frame_bcx();
   intptr_t mdx = interpreter_frame_mdx();
 
   assert(!is_bci(bcx), "should not access mdp during GC");
-  return (address)mdx;
+  return mdx;
 }
 
 void frame::interpreter_frame_set_mdp(address mdp) {

--- a/hotspot/src/share/vm/runtime/frame.hpp
+++ b/hotspot/src/share/vm/runtime/frame.hpp
@@ -248,6 +248,7 @@ class frame VALUE_OBJ_CLASS_SPEC {
   intptr_t** interpreter_frame_locals_addr() const;
   intptr_t*  interpreter_frame_bcx_addr() const;
   intptr_t*  interpreter_frame_mdx_addr() const;
+  intptr_t*    interpreter_frame_mdp_addr() const;
 
  public:
   // Locals
@@ -275,7 +276,7 @@ class frame VALUE_OBJ_CLASS_SPEC {
   void interpreter_frame_set_mdx(intptr_t mdx);
 
   // method data pointer
-  address interpreter_frame_mdp() const;
+  intptr_t interpreter_frame_mdp() const                  { return *interpreter_frame_mdp_addr(); };
   void    interpreter_frame_set_mdp(address dp);
 
   // Find receiver out of caller's (compiled) argument list
@@ -358,6 +359,8 @@ class frame VALUE_OBJ_CLASS_SPEC {
   void interpreter_frame_set_method(Method* method);
   Method** interpreter_frame_method_addr() const;
   ConstantPoolCache** interpreter_frame_cache_addr() const;
+  oop* interpreter_frame_mirror_addr() const;
+  void interpreter_frame_set_mirror(oop mirror);
 
  public:
   // Entry frames


### PR DESCRIPTION
Due to lacking of the definition of the fix_interpreter_frame_bcp_addr in JDK8u, use 'bcx' replace with 'bcp', and fix something about 'bcp'.
'