### PR TITLE
Delete const in copy_linux_riscv64.inline.hpp

### DIFF
--- a/hotspot/src/os_cpu/linux_riscv64/vm/copy_linux_riscv64.inline.hpp
+++ b/hotspot/src/os_cpu/linux_riscv64/vm/copy_linux_riscv64.inline.hpp
@@ -26,11 +26,11 @@
 #ifndef OS_CPU_LINUX_RISCV64_VM_COPY_LINUX_RISCV64_INLINE_HPP
 #define OS_CPU_LINUX_RISCV64_VM_COPY_LINUX_RISCV64_INLINE_HPP
 
-static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_conjoint_words( HeapWord* from, HeapWord* to, size_t count) {
   (void)memmove(to, from, count * HeapWordSize);
 }
 
-static inline void pd_disjoint_words_helper(const HeapWord* from, HeapWord* to, size_t count, bool is_atomic) {
+static inline void pd_disjoint_words_helper( HeapWord* from, HeapWord* to, size_t count, bool is_atomic) {
   switch (count) {
     case 8:  to[7] = from[7];   // fall through
     case 7:  to[6] = from[6];   // fall through
@@ -50,64 +50,64 @@ static inline void pd_disjoint_words_helper(const HeapWord* from, HeapWord* to, 
   }
 }
 
-static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_disjoint_words( HeapWord* from, HeapWord* to, size_t count) {
   pd_disjoint_words_helper(from, to, count, false);
 }
 
-static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_disjoint_words_atomic( HeapWord* from, HeapWord* to, size_t count) {
   pd_disjoint_words_helper(from, to, count, true);
 }
 
-static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_aligned_conjoint_words( HeapWord* from, HeapWord* to, size_t count) {
   pd_conjoint_words(from, to, count);
 }
 
-static void pd_aligned_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_aligned_disjoint_words( HeapWord* from, HeapWord* to, size_t count) {
   pd_disjoint_words(from, to, count);
 }
 
-static void pd_conjoint_bytes(const void* from, void* to, size_t count) {
+static void pd_conjoint_bytes( void* from, void* to, size_t count) {
   (void)memmove(to, from, count);
 }
 
-static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
+static void pd_conjoint_bytes_atomic( void* from, void* to, size_t count) {
   pd_conjoint_bytes(from, to, count);
 }
 
-static void pd_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
+static void pd_conjoint_jshorts_atomic( jshort* from, jshort* to, size_t count) {
   _Copy_conjoint_jshorts_atomic(from, to, count);
 }
 
-static void pd_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
+static void pd_conjoint_jints_atomic( jint* from, jint* to, size_t count) {
   _Copy_conjoint_jints_atomic(from, to, count);
 }
 
-static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
+static void pd_conjoint_jlongs_atomic( jlong* from, jlong* to, size_t count) {
   _Copy_conjoint_jlongs_atomic(from, to, count);
 }
 
-static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
+static void pd_conjoint_oops_atomic( oop* from, oop* to, size_t count) {
   assert(BytesPerLong == BytesPerOop, "jlongs and oops must be the same size.");
-  _Copy_conjoint_jlongs_atomic((const jlong*)from, (jlong*)to, count);
+  _Copy_conjoint_jlongs_atomic(( jlong*)from, (jlong*)to, count);
 }
 
-static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_arrayof_conjoint_bytes( HeapWord* from, HeapWord* to, size_t count) {
   _Copy_arrayof_conjoint_bytes(from, to, count);
 }
 
-static void pd_arrayof_conjoint_jshorts(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_arrayof_conjoint_jshorts( HeapWord* from, HeapWord* to, size_t count) {
   _Copy_arrayof_conjoint_jshorts(from, to, count);
 }
 
-static void pd_arrayof_conjoint_jints(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_arrayof_conjoint_jints( HeapWord* from, HeapWord* to, size_t count) {
   _Copy_arrayof_conjoint_jints(from, to, count);
 }
 
-static void pd_arrayof_conjoint_jlongs(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_arrayof_conjoint_jlongs( HeapWord* from, HeapWord* to, size_t count) {
   _Copy_arrayof_conjoint_jlongs(from, to, count);
 }
 
-static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t count) {
+static void pd_arrayof_conjoint_oops( HeapWord* from, HeapWord* to, size_t count) {
   assert(!UseCompressedOops, "foo!");
   assert(BytesPerLong == BytesPerOop, "jlongs and oops must be the same size");
   _Copy_arrayof_conjoint_jlongs(from, to, count);


### PR DESCRIPTION
Becasuse 'const jshort*' {aka 'const short int*'} to 'jshort*' {aka 'short int*'} is invalid, and fix 'const jshort*' to 'jshort*' .etc.