### PR TITLE
Fix CompiledMethod by using nmentod instead of CompiledMethod

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.cpp
@@ -287,7 +287,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   assert(_pc == *pc_addr || pc == *pc_addr, "must be");
   *pc_addr = pc;
   _cb = CodeCache::find_blob(pc);
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  address original_pc = nmethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     assert(original_pc == _pc, "expected original PC to be stored before patching");
     _deopt_state = is_deoptimized;

--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
@@ -56,7 +56,7 @@ inline void frame::init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
   _cb = CodeCache::find_blob(pc);
   adjust_unextended_sp();
 
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  address original_pc = nmethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
@@ -80,7 +80,7 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   _cb = CodeCache::find_blob(pc);
   adjust_unextended_sp();
 
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  address original_pc = nmethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     _pc = original_pc;
     assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),
@@ -112,7 +112,7 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   _cb = CodeCache::find_blob(_pc);
   adjust_unextended_sp();
 
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  address original_pc = nmethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;


### PR DESCRIPTION
Fix CompiledMethod by using nmentod instead of CompiledMethod due to  CompiledMethod  is not be declared.