### PR TITLE
Add is_Java_byte_ordering_different in bytes_riscv64.hpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp
@@ -35,6 +35,7 @@ class Bytes: AllStatic {
   // RISCV needs to check for alignment.
 
   // Forward declarations of the compiler-dependent implementation
+  static inline bool is_Java_byte_ordering_different(){ return true; }
   static inline u2 swap_u2(u2 x);
   static inline u4 swap_u4(u4 x);
   static inline u8 swap_u8(u8 x);


### PR DESCRIPTION
Add is_Java_byte_ordering_different in bytes_riscv64.hpp due to the Bytes class does not have is_Java_byte_ordering_different .