### PR TITLE
Fix errors in compiledIC_riscv64.cpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/assembler_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/assembler_riscv64.cpp
@@ -32,7 +32,7 @@
 #include "compiler/disassembler.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"
-#include "runtime/interfaceSupport.inline.hpp"
+//#include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 
 extern "C" void test_assembler_entry(CodeBuffer *cb);

--- a/hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp
@@ -83,13 +83,13 @@ int CompiledStaticCall::reloc_to_interp_stub() {
   return 4; // 3 in emit_to_interp_stub + 1 in emit_call
 }
 
-void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, address entry) {
-  address stub = find_stub(false /* is_aot */);
+void CompiledStaticCall::set_to_interpreted( methodHandle callee, address entry) {
+  address stub = find_stub();
   guarantee(stub != NULL, "stub not found");
 
   if (TraceICs) {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    tty->print_cr("CompiledStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }
@@ -115,7 +115,7 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   set_destination_mt_safe(stub);
 }
 
-void CompiledDirectStaticCall::set_stub_to_clean(static_stub_Relocation* static_stub) {
+void CompiledStaticCall::set_stub_to_clean(static_stub_Relocation* static_stub) {
   assert (CompiledIC_lock->is_locked() || SafepointSynchronize::is_at_safepoint(), "mt unsafe call");
   // Reset stub.
   address stub = static_stub->addr();
@@ -130,7 +130,7 @@ void CompiledDirectStaticCall::set_stub_to_clean(static_stub_Relocation* static_
 // Non-product mode code
 #ifndef PRODUCT
 
-void CompiledDirectStaticCall::verify() {
+void CompiledStaticCall::verify() {
   // Verify call.
   _call->verify();
   if (os::is_MP()) {

--- a/hotspot/src/share/vm/code/compiledIC.hpp
+++ b/hotspot/src/share/vm/code/compiledIC.hpp
@@ -333,6 +333,8 @@ class CompiledStaticCall: public NativeCall {
 #endif
   static int to_interp_stub_size();
   static int reloc_to_interp_stub();
+  static address emit_to_interp_stub(CodeBuffer &cbuf, address mark = NULL);
+  static int to_trampoline_stub_size();
 
   // State
   bool is_clean() const;


### PR DESCRIPTION
With reference to AARCH64, some functions not defined in hotspot/src/share/vm/code/compiledIC.hpphave been modified in hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp.