### PR TITLE
Add the define about pd_##name

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/globals_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/globals_riscv64.hpp
@@ -43,6 +43,8 @@ define_pd_global(uintx, CodeCacheSegmentSize,    64 TIERED_ONLY(+64)); // Tiered
 define_pd_global(intx, CodeEntryAlignment,       64);
 define_pd_global(intx, OptoLoopAlignment,        16);
 define_pd_global(intx, InlineFrequencyCount,     100);
+define_pd_global(intx, PreInflateSpin,           10);
+define_pd_global(bool, ConvertSleepToYield,      true);
 
 #define DEFAULT_STACK_YELLOW_PAGES (2)
 #define DEFAULT_STACK_RED_PAGES (1)

--- a/hotspot/src/cpu/riscv64/vm/icBuffer_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/icBuffer_riscv64.cpp
@@ -28,7 +28,7 @@
 #include "asm/macroAssembler.hpp"
 #include "asm/macroAssembler.inline.hpp"
 #include "code/icBuffer.hpp"
-#include "gc/shared/collectedHeap.inline.hpp"
+//#include "gc/shared/collectedHeap.inline.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "memory/resourceArea.hpp"
 #include "nativeInst_riscv64.hpp"


### PR DESCRIPTION
1、/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/runtime/globals.hpp:4087:75: error: 'pd_PreInflateSpin' was not declared in this scope; did you mean 'PreInflateSpin'?
 4087 | #define MATERIALIZE_PD_PRODUCT_FLAG(type, name, doc)          type name = pd_##name;
      |                                                                           ^~~
2、/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/runtime/globals.hpp:4087:75: error: 'pd_ConvertSleepToYield' was not declared in this scope; did you mean 'ConvertSleepToYield'?
 4087 | #define MATERIALIZE_PD_PRODUCT_FLAG(type, name, doc)          type name = pd_##name;

3、/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/cpu/riscv64/vm/icBuffer_riscv64.cpp:31:10: fatal error: gc/shared/collectedHeap.inline.hpp: No such file or directory
   31 | #include "gc/shared/collectedHeap.inline.hpp"