### PR TITLE
fix interp_masm_riscv64.cpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
@@ -280,7 +280,7 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(
   get_constant_pool(result);
   // load pointer for resolved_references[] objArray
   ld(result, Address(result, ConstantPool::cache_offset_in_bytes()));
-  ld(result, Address(result, ConstantPoolCache::resolved_references_offset_in_bytes()));
+  ld(result, Address(result, ConstantPool::resolved_references_offset_in_bytes()));
   resolve_oop_handle(result, tmp);
   // Add in the index
   addi(index, index, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
@@ -716,7 +716,7 @@ void InterpreterMacroAssembler::remove_activation(
   // get sender esp
   ld(esp,
      Address(fp, frame::interpreter_frame_sender_sp_offset * wordSize));
-  if (StackReservedPages > 0) {
+  if (pd_StackReservedPages > 0) {
     // testing if reserved zone needs to be re-enabled
     Label no_reserved_zone_enabling;
 

--- a/hotspot/src/share/vm/interpreter/interpreterRuntime.hpp
+++ b/hotspot/src/share/vm/interpreter/interpreterRuntime.hpp
@@ -101,6 +101,7 @@ class InterpreterRuntime: AllStatic {
   static void    create_exception(JavaThread* thread, char* name, char* message);
   static void    create_klass_exception(JavaThread* thread, char* name, oopDesc* obj);
   static address exception_handler_for_exception(JavaThread* thread, oopDesc* exception);
+  static void    throw_delayed_StackOverflowError(JavaThread* thread);
 #if INCLUDE_JVMTI
   static void    member_name_arg_or_null(JavaThread* thread, address dmh, Method* m, address bcp);
 #endif

--- a/hotspot/src/share/vm/interpreter/templateInterpreter.hpp
+++ b/hotspot/src/share/vm/interpreter/templateInterpreter.hpp
@@ -160,6 +160,7 @@ class TemplateInterpreter: public AbstractInterpreter {
   static int        distance_from_dispatch_table(TosState state){ return _active_table.distance_from(state); }
   static address*   normal_table(TosState state)                { return _normal_table.table_for(state); }
   static address*   normal_table()                              { return _normal_table.table_for(); }
+  static address*   safept_table(TosState state)                { return _safept_table.table_for(state); }
 
   // Support for invokes
   static address*   invoke_return_entry_table()                 { return _invoke_return_entry; }

--- a/hotspot/src/share/vm/memory/allocation.hpp
+++ b/hotspot/src/share/vm/memory/allocation.hpp
@@ -155,8 +155,9 @@ enum MemoryType {
   mtTest              = 0x0D,  // Test type for verifying NMT
   mtTracing           = 0x0E,  // memory used for Tracing
   mtNone              = 0x0F,  // undefined
-  mt_number_of_types  = 0x10   // number of memory types (mtDontTrack
+  mt_number_of_types  = 0x10,   // number of memory types (mtDontTrack
                                  // is not included as validate type)
+  mtLogging          // memory for logging
 };
 
 typedef MemoryType MEMFLAGS;

--- a/hotspot/src/share/vm/oops/constantPool.hpp
+++ b/hotspot/src/share/vm/oops/constantPool.hpp
@@ -101,6 +101,7 @@ class ConstantPool : public Metadata {
   // object index to original constant pool index
   jobject              _resolved_references;
   Array<u2>*           _reference_map;
+  Array<Klass*>*       _resolved_klasses;
 
   enum {
     _has_preresolution = 1,           // Flags
@@ -239,6 +240,8 @@ class ConstantPool : public Metadata {
   static int cache_offset_in_bytes()        { return offset_of(ConstantPool, _cache); }
   static int pool_holder_offset_in_bytes()  { return offset_of(ConstantPool, _pool_holder); }
   static int resolved_references_offset_in_bytes() { return offset_of(ConstantPool, _resolved_references); }
+  static int resolved_klasses_offset_in_bytes()    { return offset_of(ConstantPool, _resolved_klasses);}
+ 
 
   // Storing constants
 

--- a/hotspot/src/share/vm/runtime/frame.cpp
+++ b/hotspot/src/share/vm/runtime/frame.cpp
@@ -500,14 +500,14 @@ void frame::interpreter_frame_set_mdx(intptr_t mdx) {
   *interpreter_frame_mdx_addr() = mdx;
 }
 
-intptr_t frame::interpreter_frame_mdp() const {
+address frame::interpreter_frame_mdp() const {
   assert(ProfileInterpreter, "must be profiling interpreter");
   assert(is_interpreted_frame(), "interpreted frame expected");
   intptr_t bcx = interpreter_frame_bcx();
   intptr_t mdx = interpreter_frame_mdx();
 
   assert(!is_bci(bcx), "should not access mdp during GC");
-  return mdx;
+  return (address)mdx;
 }
 
 void frame::interpreter_frame_set_mdp(address mdp) {

--- a/hotspot/src/share/vm/runtime/frame.hpp
+++ b/hotspot/src/share/vm/runtime/frame.hpp
@@ -248,7 +248,7 @@ class frame VALUE_OBJ_CLASS_SPEC {
   intptr_t** interpreter_frame_locals_addr() const;
   intptr_t*  interpreter_frame_bcx_addr() const;
   intptr_t*  interpreter_frame_mdx_addr() const;
-  intptr_t*    interpreter_frame_mdp_addr() const;
+  intptr_t*  interpreter_frame_mdp_addr() const;
 
  public:
   // Locals
@@ -276,7 +276,7 @@ class frame VALUE_OBJ_CLASS_SPEC {
   void interpreter_frame_set_mdx(intptr_t mdx);
 
   // method data pointer
-  intptr_t interpreter_frame_mdp() const;
+  address interpreter_frame_mdp() const;
   void    interpreter_frame_set_mdp(address dp);
 
   // Find receiver out of caller's (compiled) argument list

--- a/hotspot/src/share/vm/runtime/sharedRuntime.hpp
+++ b/hotspot/src/share/vm/runtime/sharedRuntime.hpp
@@ -199,6 +199,7 @@ class SharedRuntime: AllStatic {
   static address continuation_for_implicit_exception(JavaThread* thread,
                                                      address faulting_pc,
                                                      ImplicitExceptionKind exception_kind);
+  static void enable_stack_reserved_zone(JavaThread* thread);
 
   // Shared stub locations
   static address get_poll_stub(address pc);

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -255,6 +255,7 @@ class Thread: public ThreadShadow {
   friend class Pause_No_Safepoint_Verifier;
   friend class ThreadLocalStorage;
   friend class GC_locker;
+  volatile void* _polling_page;                 // Thread local polling page
 
   ThreadLocalAllocBuffer _tlab;                 // Thread-local eden
   jlong _allocated_bytes;                       // Cumulative number of bytes allocated on
@@ -613,6 +614,7 @@ protected:
 
   static ByteSize stack_base_offset()            { return byte_offset_of(Thread, _stack_base ); }
   static ByteSize stack_size_offset()            { return byte_offset_of(Thread, _stack_size ); }
+  static ByteSize polling_page_offset()          { return byte_offset_of(Thread, _polling_page); }
 
 #define TLAB_FIELD_OFFSET(name) \
   static ByteSize tlab_##name##_offset()         { return byte_offset_of(Thread, _tlab) + ThreadLocalAllocBuffer::name##_offset(); }
@@ -915,6 +917,7 @@ class JavaThread: public Thread {
   // Precompute the limit of the stack as used in stack overflow checks.
   // We load it from here to simplify the stack overflow check in assembly.
   address          _stack_overflow_limit;
+  address          _reserved_stack_activation;
 
   // Compiler exception handling (NOTE: The _exception_oop is *NOT* the same as _pending_exception. It is
   // used to temp. parsing values into and out of the runtime system during exception handling for compiled
@@ -1373,6 +1376,7 @@ class JavaThread: public Thread {
   static ByteSize is_method_handle_return_offset() { return byte_offset_of(JavaThread, _is_method_handle_return); }
   static ByteSize stack_guard_state_offset()     { return byte_offset_of(JavaThread, _stack_guard_state   ); }
   static ByteSize suspend_flags_offset()         { return byte_offset_of(JavaThread, _suspend_flags       ); }
+  static ByteSize reserved_stack_activation_offset() { return byte_offset_of(JavaThread, _reserved_stack_activation); }
 
   static ByteSize do_not_unlock_if_synchronized_offset() { return byte_offset_of(JavaThread, _do_not_unlock_if_synchronized); }
   static ByteSize should_post_on_exceptions_flag_offset() {

--- a/hotspot/src/share/vm/utilities/debug.hpp
+++ b/hotspot/src/share/vm/utilities/debug.hpp
@@ -154,6 +154,7 @@ do {                                                                         \
   #define assert(p,msg)
   #define assert_status(p,status,msg)
   #define assert_if_no_error(cond,msg)
+  #define vmassert(p, ...) 
 #endif // #ifdef ASSERT
 
 #define precond(p)   assert(p, "precond")


### PR DESCRIPTION
3、
```
/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/logging/logLevel.hpp: In static member function 'static const char* LogLevel::name(LogLevel::type)':
/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/logging/logLevel.hpp:69:5: error: 'vmassert' was not declared in this scope; did you mean 'assert'?
   69 |     vmassert(level >= 0 && level < LogLevel::Count, "Invalid level (enum value %d).", level);
```
```
/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/logging/logOutputList.hpp:49:42: error: 'mtLogging' was not declared in this scope
   49 |   struct LogOutputNode : public CHeapObj<mtLogging> {
```
```
/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/logging/logOutputList.hpp:49:51: error: template argument 1 is invalid
   49 |   struct LogOutputNode : public CHeapObj<mtLogging> {
      |                                                   ^
```
```
error: 'resolved_references_offset_in_bytes' is not a member of 'ConstantPoolCache'
  283 |   ld(result, Address(result, ConstantPoolCache::resolved_references_offset_in_bytes()));
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
rror: 'safept_table' is not a member of 'Interpreter'
  509 |   address* const safepoint_table = Interpreter::safept_table(state);
```

```
error: 'StackReservedPages' was not declared in this scope; did you mean 'pd_StackReservedPages'?
  719 |   if (StackReservedPages > 0)
```

```
error: 'enable_stack_reserved_zone' is not a member of 'SharedRuntime'
  727 |       CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone), xthread);
```
```
'throw_delayed_StackOverflowError' is not a member of 'InterpreterRuntime'
  729 |                                     InterpreterRuntime::throw_delayed_StackOverflowError));
```

```
error: invalid conversion from 'intptr_t' {aka 'long int'} to 'address' {aka 'unsigned char*'} [-fpermissive]
  999 |   ProfileData* data = h_mdo->data_at(h_mdo->dp_to_di(fr.interpreter_frame_mdp()));
```