### PR TITLE
Fix frame riscv64andframe riscv6 inline hpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.cpp
@@ -59,8 +59,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
   address   unextended_sp = (address)_unextended_sp;
 
   // consider stack guards when trying to determine "safe" stack pointers
-  static size_t stack_guard_size = os::uses_stack_guard_pages() ?
-    (JavaThread::stack_red_zone_size() + JavaThread::stack_yellow_zone_size()) : 0;
+  //static size_t stack_guard_size = os::uses_stack_guard_pages() ?
+  //  (JavaThread::stack_red_zone_size() + JavaThread::stack_yellow_zone_size()) : 0;
+  static size_t stack_guard_size = os::uses_stack_guard_pages() ? (StackYellowPages + StackRedPages) * os::vm_page_size() : 0;
   assert_cond(thread != NULL);
   size_t usable_stack_size = thread->stack_size() - stack_guard_size;
 
@@ -240,7 +241,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
     // because the return address counts against the callee's frame.
 
     if (sender_blob->frame_size() <= 0) {
-      assert(!sender_blob->is_compiled(), "should count return address at least");
+      assert(!sender_blob->is_nmethod(), "should count return address at least");
       return false;
     }
 
@@ -249,7 +250,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
     // should not be anything but the call stub (already covered), the interpreter (already covered)
     // or an nmethod.
 
-    if (!sender_blob->is_compiled()) {
+    if (!sender_blob->is_nmethod()) {
         return false;
     }
 
@@ -551,8 +552,8 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   }
 
   // validate bci/bcx
-  address  bcp    = interpreter_frame_bcp();
-  if (m->validate_bci_from_bcp(bcp) < 0) {
+  address  bcp    = interpreter_frame_bcx();
+  if (m->validate_bci_from_bcx(bcp) < 0) {
     return false;
   }
 

--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.inline.hpp
@@ -44,7 +44,7 @@ inline frame::frame() {
 }
 
 static int spin;
-oop* interpreter_frame_mirror_addr() const;
+//oop* interpreter_frame_mirror_addr() const;
 inline void frame::init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
   intptr_t a = intptr_t(ptr_sp);
   intptr_t b = intptr_t(ptr_fp);
@@ -56,7 +56,7 @@ inline void frame::init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
   _cb = CodeCache::find_blob(pc);
   adjust_unextended_sp();
 
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  address original_pc = nmethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     _pc = original_pc;
     _deopt_state = is_deoptimized;
@@ -80,7 +80,7 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   _cb = CodeCache::find_blob(pc);
   adjust_unextended_sp();
 
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  address original_pc = nmethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     _pc = original_pc;
     assert(_cb->as_compiled_method()->insts_contains_inclusive(_pc),

--- a/hotspot/src/share/vm/runtime/frame.hpp
+++ b/hotspot/src/share/vm/runtime/frame.hpp
@@ -321,7 +321,7 @@ class frame VALUE_OBJ_CLASS_SPEC {
 
   // Address of the temp oop in the frame. Needed as GC root.
   oop* interpreter_frame_temp_oop_addr() const;
-
+  oop* interpreter_frame_mirror_addr() const;
   // BasicObjectLocks:
   //
   // interpreter_frame_monitor_begin is higher in memory than interpreter_frame_monitor_end


### PR DESCRIPTION
1、' static size_t stack_guard_size = os::uses_stack_guard_pages() ?
    (JavaThread::stack_red_zone_size() + JavaThread::stack_yellow_zone_size()) : 0;'--->' static size_t stack_guard_size = os::uses_stack_guard_pages() ? (StackYellowPages + StackRedPages) * os::vm_page_size() : 0;'

2、'is_compiled'-->'is_nmethod'

3、'CompiledMethod'--->'nmethod'