### PR TITLE
Fix compiledIC.hpp & compiledIC_riscv64.cpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp
@@ -83,13 +83,13 @@ int CompiledStaticCall::reloc_to_interp_stub() {
   return 4; // 3 in emit_to_interp_stub + 1 in emit_call
 }
 
-void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, address entry) {
-  address stub = find_stub(false /* is_aot */);
+void CompiledStaticCall::set_to_interpreted( methodHandle& callee, address entry) {
+  address stub = find_stub();
   guarantee(stub != NULL, "stub not found");
 
   if (TraceICs) {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    tty->print_cr("CompiledStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }
@@ -115,7 +115,7 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   set_destination_mt_safe(stub);
 }
 
-void CompiledDirectStaticCall::set_stub_to_clean(static_stub_Relocation* static_stub) {
+void CompiledStaticCall::set_stub_to_clean(static_stub_Relocation* static_stub) {
   assert (CompiledIC_lock->is_locked() || SafepointSynchronize::is_at_safepoint(), "mt unsafe call");
   // Reset stub.
   address stub = static_stub->addr();
@@ -130,7 +130,7 @@ void CompiledDirectStaticCall::set_stub_to_clean(static_stub_Relocation* static_
 // Non-product mode code
 #ifndef PRODUCT
 
-void CompiledDirectStaticCall::verify() {
+void CompiledStaticCall::verify() {
   // Verify call.
   _call->verify();
   if (os::is_MP()) {

--- a/hotspot/src/share/vm/code/compiledIC.hpp
+++ b/hotspot/src/share/vm/code/compiledIC.hpp
@@ -326,14 +326,15 @@ class CompiledStaticCall: public NativeCall {
   friend CompiledStaticCall* compiledStaticCall_at(Relocation* call_site);
 
   // Code
-#if defined(AARCH64) && !defined(ZERO)
+#if defined(AARCH64) && !defined(ZERO) || defined(RISCV64)
   static address emit_to_interp_stub(CodeBuffer &cbuf, address mark);
 #else
   static address emit_to_interp_stub(CodeBuffer &cbuf);
 #endif
   static int to_interp_stub_size();
   static int reloc_to_interp_stub();
-
+  static int to_trampoline_stub_size();
+ 
   // State
   bool is_clean() const;
   bool is_call_to_compiled() const;

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -1364,7 +1364,7 @@ class JavaThread: public Thread {
   static ByteSize vm_result_offset()             { return byte_offset_of(JavaThread, _vm_result           ); }
   static ByteSize vm_result_2_offset()           { return byte_offset_of(JavaThread, _vm_result_2         ); }
   static ByteSize thread_state_offset()          { return byte_offset_of(JavaThread, _thread_state        ); }
-  static ByteSize saved_exception_pc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc  ); }
+  static ByteSize saved_exception_Ppc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc  ); }
   static ByteSize osthread_offset()              { return byte_offset_of(JavaThread, _osthread            ); }
   static ByteSize exception_oop_offset()         { return byte_offset_of(JavaThread, _exception_oop       ); }
   static ByteSize exception_pc_offset()          { return byte_offset_of(JavaThread, _exception_pc        ); }

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -1364,7 +1364,7 @@ class JavaThread: public Thread {
   static ByteSize vm_result_offset()             { return byte_offset_of(JavaThread, _vm_result           ); }
   static ByteSize vm_result_2_offset()           { return byte_offset_of(JavaThread, _vm_result_2         ); }
   static ByteSize thread_state_offset()          { return byte_offset_of(JavaThread, _thread_state        ); }
-  static ByteSize saved_exception_Ppc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc  ); }
+  static ByteSize saved_exception_pc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc  ); }
   static ByteSize osthread_offset()              { return byte_offset_of(JavaThread, _osthread            ); }
   static ByteSize exception_oop_offset()         { return byte_offset_of(JavaThread, _exception_oop       ); }
   static ByteSize exception_pc_offset()          { return byte_offset_of(JavaThread, _exception_pc        ); }


### PR DESCRIPTION
1、“CompiledDirectStaticCall”--->'CompiledStaticCall'
2.Add to_trampoline_stub_size
3.Add the support for rv64 by "defined(RISCV64)"