### PR TITLE
Fix templateInterpreterGenerator_riscv64.cpp by adding

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.cpp
@@ -26,10 +26,10 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
-#include "gc/shared/barrierSetAssembler.hpp"
+#include "barrierSetAssembler_riscv64.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/bytecodeTracer.hpp"
-#include "interpreter/interp_masm.hpp"
+//#include "interpreter/interp_masm.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/interpreterRuntime.hpp"
 #include "interpreter/templateInterpreterGenerator.hpp"
@@ -911,7 +911,7 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
 
   // Load the value of the referent field.
   const Address field_address(local_0, referent_offset);
-  BarrierSetAssembler *bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  BarrierSetAssembler *bs = BarrierSetRv::barrier_set()->barrier_set_assembler();
   bs->load_at(_masm, IN_HEAP | ON_WEAK_OOP_REF, T_OBJECT, local_0, field_address, /*tmp1*/ t1, /*tmp2*/ t0);
 
   // areturn

--- a/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2013, Red Hat Inc.
+ * Copyright (c) 1997, 2010, Oracle and/or its affiliates.
+ * All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV64_VM_TEMPLATEINTERPRETERGENERATOR_RISCV64_HPP
+#define CPU_RISCV64_VM_TEMPLATEINTERPRETERGENERATOR_RISCV64_HPP
+
+ protected:
+
+void generate_fixed_frame(bool native_call);
+
+ // address generate_asm_interpreter_entry(bool synchronized);
+
+#endif // CPU_RISCV64_VM_TEMPLATEINTERPRETERGENERATOR_RISCV64_HPP

--- a/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
+++ b/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
@@ -103,6 +103,8 @@ class AbstractInterpreter: AllStatic {
     java_util_zip_CRC32_updateBytes,                            // implementation of java.util.zip.CRC32.updateBytes()
     java_util_zip_CRC32_updateByteBuffer,                       // implementation of java.util.zip.CRC32.updateByteBuffer()
     number_of_method_entries,
+    java_lang_math_fmaF,                                        // implementation of java.lang.Math.fma   (x, y, z)
+    java_lang_math_fmaD,                                        // implementation of java.lang.Math.fma   (x, y, z)
     invalid = -1
   };
 

--- a/hotspot/src/share/vm/oops/methodCounters.hpp
+++ b/hotspot/src/share/vm/oops/methodCounters.hpp
@@ -128,6 +128,12 @@ class MethodCounters: public MetaspaceObj {
   static int interpreter_invocation_counter_offset_in_bytes() {
     return offset_of(MethodCounters, _interpreter_invocation_count);
   }
-
+  static ByteSize interpreter_profile_limit_offset() {
+    return byte_offset_of(MethodCounters, _interpreter_profile_limit);
+  }
+ 
+  static ByteSize interpreter_invocation_limit_offset() {
+    return byte_offset_of(MethodCounters, _interpreter_invocation_limit);
+  }
 };
 #endif //SHARE_VM_OOPS_METHODCOUNTERS_HPP

--- a/hotspot/src/share/vm/oops/methodData.hpp
+++ b/hotspot/src/share/vm/oops/methodData.hpp
@@ -2448,7 +2448,9 @@ public:
   static ByteSize backedge_counter_offset() {
     return byte_offset_of(MethodData, _backedge_counter);
   }
-
+  static ByteSize invoke_mask_offset() {
+    return byte_offset_of(MethodData, _invoke_mask);
+  }
   static ByteSize parameters_type_data_di_offset() {
     return byte_offset_of(MethodData, _parameters_type_data_di);
   }

--- a/hotspot/src/share/vm/runtime/globals.hpp
+++ b/hotspot/src/share/vm/runtime/globals.hpp
@@ -624,6 +624,9 @@ class CommandLineFlags {
   product(intx, UseSSE, 99,                                                 \
           "Highest supported SSE instructions set on x86/x64")              \
                                                                             \
+  product(bool, UseFMA, false,                                              \
+          "Control whether FMA instructions are used when available")       \
+                                                                            \
   product(bool, UseAES, false,                                              \
           "Control whether AES instructions can be used on x86/x64")        \
                                                                             \
@@ -2650,6 +2653,9 @@ class CommandLineFlags {
   develop(bool, EagerInitialization, false,                                 \
           "Eagerly initialize classes if possible")                         \
                                                                             \
+  diagnostic(bool, LogTouchedMethods, false,                                \
+          "Log methods which have been ever touched in runtime")            \
+                                                                            \                                                                            \
   develop(bool, TraceMethodReplacement, false,                              \
           "Print when methods are replaced do to recompilation")            \
                                                                             \

--- a/hotspot/src/share/vm/runtime/stubRoutines.hpp
+++ b/hotspot/src/share/vm/runtime/stubRoutines.hpp
@@ -135,7 +135,7 @@ class StubRoutines: AllStatic {
   static address _throw_NullPointerException_at_call_entry;
   static address _throw_StackOverflowError_entry;
   static address _handler_for_unsafe_access_entry;
-
+  static address _throw_delayed_StackOverflowError_entry;
   static address _atomic_xchg_entry;
   static address _atomic_xchg_ptr_entry;
   static address _atomic_store_entry;
@@ -224,6 +224,13 @@ class StubRoutines: AllStatic {
   static address _mulAdd;
   static address _montgomeryMultiply;
   static address _montgomerySquare;
+  static address _dsin;
+  static address _dcos;
+  static address _dtan;
+  static address _dlog;
+  static address _dlog10;
+  static address _dexp;
+  static address _dpow;
 
   // These are versions of the java.lang.Math methods which perform
   // the same operations as the intrinsic version.  They are used for
@@ -292,7 +299,7 @@ class StubRoutines: AllStatic {
   static address throw_IncompatibleClassChangeError_entry(){ return _throw_IncompatibleClassChangeError_entry; }
   static address throw_NullPointerException_at_call_entry(){ return _throw_NullPointerException_at_call_entry; }
   static address throw_StackOverflowError_entry()          { return _throw_StackOverflowError_entry; }
-
+  static address throw_delayed_StackOverflowError_entry()  { return _throw_delayed_StackOverflowError_entry; }
   // Exceptions during unsafe access - should throw Java exception rather
   // than crash.
   static address handler_for_unsafe_access()               { return _handler_for_unsafe_access_entry; }
@@ -391,7 +398,12 @@ class StubRoutines: AllStatic {
   static address select_fill_function(BasicType t, bool aligned, const char* &name);
 
   static address zero_aligned_words()   { return _zero_aligned_words; }
-
+  static address dlog()                { return _dlog; }
+  static address dtan()                { return _dtan; }
+  static address dlog10()              { return _dlog10; }
+  static address dexp()                { return _dexp; }
+  static address dpow()                { return _dpow; }
+  static address dsin()                { return _dsin; }
   static double  intrinsic_log(double d) {
     assert(_intrinsic_log != NULL, "must be defined");
     return _intrinsic_log(d);


### PR DESCRIPTION
1.Add hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.hpp
2.Add interpreter_profile_limit_offset/interpreter_invocation_limit_offset
3.Add invoke_mask_offset
4. Add the definition of UseFMA/LogTouchedMethods in hotspot/src/share/vm/runtime/globals.hpp
5. in hotspot/src/share/vm/runtime/stubRoutines.hpp / hotspot/src/share/vm/runtime/thread.hpp fix something.