### PR TITLE
Add is_Java_byte_ordering_different() in bytes_riscv64

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp
@@ -38,7 +38,7 @@ class Bytes: AllStatic {
   static inline u2 swap_u2(u2 x);
   static inline u4 swap_u4(u4 x);
   static inline u8 swap_u8(u8 x);
-
+  static inline bool is_Java_byte_ordering_different(){ return true; }
   static inline u2 get_native_u2(address p) {
     if ((intptr_t(p) & 1) == 0) {
       return *(u2*)p;


### PR DESCRIPTION
Add static inline bool is_Java_byte_ordering_different(){ return true; } in hotspot/src/cpu/riscv64/vm/bytes_riscv64.hpp