### PR TITLE
Fix ARCH_FLAGS by deleteing 3 argus

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/globals_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/globals_riscv64.hpp
@@ -29,6 +29,7 @@
 
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
+#include "memory/allocation.hpp"
 
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
@@ -88,10 +89,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
                    product,                                             \
                    diagnostic,                                          \
                    experimental,                                        \
-                   notproduct,                                          \
-                   range,                                               \
-                   constraint,                                          \
-                   writeable)                                           \
+                   notproduct)                                          \
                                                                         \
   product(bool, NearCpool, true,                                        \
          "constant pool is close to instructions")                      \
@@ -107,7 +105,6 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use DC ZVA for block zeroing")                               \
   product(intx, BlockZeroingLowLimit, 256,                              \
           "Minimum size in bytes when block zeroing will be used")      \
-          range(1, max_jint)                                            \
   product(bool, TraceTraps, false, "Trace all traps the signal handler")\
   product(bool, UseConservativeFence, true,                             \
           "Extend i for r and o for w in the pred/succ flags of fence;" \

--- a/hotspot/src/share/vm/runtime/globals.hpp
+++ b/hotspot/src/share/vm/runtime/globals.hpp
@@ -2655,7 +2655,7 @@ class CommandLineFlags {
                                                                             \
   diagnostic(bool, LogTouchedMethods, false,                                \
           "Log methods which have been ever touched in runtime")            \
-                                                                            \                                                                            \
+                                                                            \
   develop(bool, TraceMethodReplacement, false,                              \
           "Print when methods are replaced do to recompilation")            \
                                                                             \


### PR DESCRIPTION
The error: macro "ARCH_FLAGS" requires 8 arguments, but only 5 given
 4114 | ARCH_FLAGS(DECLARE_DEVELOPER_FLAG, DECLARE_PRODUCT_FLAG, DECLARE_DIAGNOSTIC_FLAG, DECLARE_EXPERIMENTAL_FLAG, DECLARE_NOTPRODUCT_FLAG),so delete 3argus.