### PR TITLE
0902 add riscv64

### DIFF
--- a/hotspot/agent/src/os/linux/LinuxDebuggerLocal.c
+++ b/hotspot/agent/src/os/linux/LinuxDebuggerLocal.c
@@ -337,7 +337,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLo
   return (err == PS_OK)? array : 0;
 }
 
-#if defined(i386) || defined(amd64) || defined(sparc) || defined(sparcv9) || defined(aarch64)
+#if defined(i386) || defined(amd64) || defined(sparc) || defined(sparcv9) || defined(aarch64) || defined(__riscv)
 JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_getThreadIntegerRegisterSet0
   (JNIEnv *env, jobject this_obj, jint lwp_id) {
 

--- a/hotspot/agent/src/os/linux/libproc.h
+++ b/hotspot/agent/src/os/linux/libproc.h
@@ -36,7 +36,7 @@
 
 #include <sys/ptrace.h>
 
-#if defined(aarch64)
+#if defined(aarch64) || defined(__riscv)
 #include "asm/ptrace.h"
 #endif
 

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -1418,7 +1418,7 @@ void os::Linux::clock_init() {
 
 #ifndef SYS_clock_getres
 
-#if defined(IA32) || defined(AMD64) || defined(AARCH64)
+#if defined(IA32) || defined(AMD64) || defined(AARCH64) || defined(RISCV64)
 #define SYS_clock_getres IA32_ONLY(266)  AMD64_ONLY(229) AARCH64_ONLY(114)
 #define sys_clock_getres(x,y)  ::syscall(SYS_clock_getres, x, y)
 #else
@@ -2968,7 +2968,7 @@ int os::Linux::sched_getcpu_syscall(void) {
   typedef long (*vgetcpu_t)(unsigned int *cpu, unsigned int *node, unsigned long *tcache);
   vgetcpu_t vgetcpu = (vgetcpu_t)VSYSCALL_ADDR(__NR_vgetcpu);
   retval = vgetcpu(&cpu, NULL, NULL);
-#elif defined(IA32) || defined(AARCH64)
+#elif defined(IA32) || defined(AARCH64) || defined(RISCV64)
 # ifndef SYS_getcpu
 #  define SYS_getcpu AARCH64_ONLY(168) IA32_ONLY(318)
 # endif

--- a/hotspot/src/share/vm/code/compiledIC.hpp
+++ b/hotspot/src/share/vm/code/compiledIC.hpp
@@ -326,7 +326,7 @@ class CompiledStaticCall: public NativeCall {
   friend CompiledStaticCall* compiledStaticCall_at(Relocation* call_site);
 
   // Code
-#if defined(AARCH64) && !defined(ZERO) || defined(RISCV64)
+#if (defined(AARCH64) || defined(RISCV64) )&& !defined(ZERO)
   static address emit_to_interp_stub(CodeBuffer &cbuf, address mark);
 #else
   static address emit_to_interp_stub(CodeBuffer &cbuf);

--- a/hotspot/src/share/vm/interpreter/interpreterRuntime.cpp
+++ b/hotspot/src/share/vm/interpreter/interpreterRuntime.cpp
@@ -1293,7 +1293,7 @@ IRT_ENTRY(void, InterpreterRuntime::prepare_native_call(JavaThread* thread, Meth
   // preparing the same method will be sure to see non-null entry & mirror.
 IRT_END
 
-#if defined(IA32) || defined(AMD64) || defined(ARM) || defined(AARCH64)
+#if defined(IA32) || defined(AMD64) || defined(ARM) || defined(AARCH64) || defined(RISCV64)
 IRT_LEAF(void, InterpreterRuntime::popframe_move_outgoing_args(JavaThread* thread, void* src_address, void* dest_address))
   if (src_address == dest_address) {
     return;

--- a/hotspot/src/share/vm/interpreter/interpreterRuntime.hpp
+++ b/hotspot/src/share/vm/interpreter/interpreterRuntime.hpp
@@ -157,7 +157,7 @@ class InterpreterRuntime: AllStatic {
                                         Method* method,
                                         intptr_t* from, intptr_t* to);
 
-#if defined(IA32) || defined(AMD64) || defined(ARM) || defined(AARCH64)
+#if defined(IA32) || defined(AMD64) || defined(ARM) || defined(AARCH64) || defined(RISCV64)
   // Popframe support (only needed on x86, AMD64 and ARM)
   static void popframe_move_outgoing_args(JavaThread* thread, void* src_address, void* dest_address);
 #endif

--- a/hotspot/src/share/vm/jfr/utilities/jfrBigEndian.hpp
+++ b/hotspot/src/share/vm/jfr/utilities/jfrBigEndian.hpp
@@ -116,7 +116,7 @@ inline T JfrBigEndian::read_unaligned(const address location) {
 inline bool JfrBigEndian::platform_supports_unaligned_reads(void) {
 #if defined(IA32) || defined(AMD64) || defined(PPC) || defined(S390)
   return true;
-#elif defined(SPARC) || defined(ARM) || defined(AARCH64)
+#elif defined(SPARC) || defined(ARM) || defined(AARCH64) || defined(RISCV64)
   return false;
 #else
   #warning "Unconfigured platform"

--- a/hotspot/src/share/vm/memory/allocation.inline.hpp
+++ b/hotspot/src/share/vm/memory/allocation.inline.hpp
@@ -37,7 +37,7 @@ void trace_heap_free(void *p);
 #ifndef PRODUCT
 // Increments unsigned long value for statistics (not atomic on MP).
 inline void inc_stat_counter(volatile julong* dest, julong add_value) {
-#if defined(SPARC) || defined(X86) || defined(AARCH64)
+#if defined(SPARC) || defined(X86) || defined(AARCH64) || defined(RISCV64)
   // Sparc, X86 and AArch64 have atomic jlong (8 bytes) instructions
   julong value = Atomic::load((volatile jlong*)dest);
   value += add_value;

--- a/hotspot/src/share/vm/runtime/advancedThresholdPolicy.cpp
+++ b/hotspot/src/share/vm/runtime/advancedThresholdPolicy.cpp
@@ -57,7 +57,7 @@ void AdvancedThresholdPolicy::initialize() {
   FLAG_SET_ERGO(intx, CICompilerCount, c1_count() + c2_count());
 
   // Some inlining tuning
-#if defined(X86) || defined(AARCH64)
+#if defined(X86) || defined(AARCH64) || defined(RISCV64)
   if (FLAG_IS_DEFAULT(InlineSmallCode)) {
     FLAG_SET_DEFAULT(InlineSmallCode, 2000);
   }

--- a/hotspot/src/share/vm/runtime/globals.hpp
+++ b/hotspot/src/share/vm/runtime/globals.hpp
@@ -745,6 +745,9 @@ class CommandLineFlags {
   product(bool, UseAESIntrinsics, false,                                    \
           "Use intrinsics for AES versions of crypto")                      \
                                                                             \
+ diagnostic(bool, UseAESCTRIntrinsics, false,                               \
+          "Use intrinsics for the paralleled version of AES/CTR crypto")    \
+                                                                            \
   product(bool, UseSHA1Intrinsics, false,                                   \
           "Use intrinsics for SHA-1 crypto hash function")                  \
                                                                             \
@@ -756,6 +759,9 @@ class CommandLineFlags {
                                                                             \
   product(bool, UseCRC32Intrinsics, false,                                  \
           "use intrinsics for java.util.zip.CRC32")                         \
+                                                                            \
+  diagnostic(bool, UseCRC32CIntrinsics, false,                              \
+          "use intrinsics for java.util.zip.CRC32C")                        \
                                                                             \
   develop(bool, TraceCallFixup, false,                                      \
           "Trace all call fixups")                                          \

--- a/hotspot/src/share/vm/runtime/os.hpp
+++ b/hotspot/src/share/vm/runtime/os.hpp
@@ -643,6 +643,7 @@ class os: AllStatic {
   static void print_siginfo(outputStream* st, void* siginfo);
   static void print_signal_handlers(outputStream* st, char* buf, size_t buflen);
   static void print_date_and_time(outputStream* st, char* buf, size_t buflen);
+  static void print_instructions(outputStream* st, address pc, int unitsize);
 
   static void print_location(outputStream* st, intptr_t x, bool verbose = false);
   static size_t lasterror(char *buf, size_t len);
@@ -824,6 +825,7 @@ class os: AllStatic {
 
   // Hook for os specific jvm options that we don't want to abort on seeing
   static bool obsolete_option(const JavaVMOption *option);
+  static int extra_bang_size_in_bytes();
 
   // Extensions
 #include "runtime/os_ext.hpp"

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -1052,7 +1052,7 @@ class JavaThread: public Thread {
   address last_Java_pc(void)                     { return _anchor.last_Java_pc(); }
 
   // Safepoint support
-#if !(defined(PPC64) || defined(AARCH64)) || defined(RISCV64)
+#if !(defined(PPC64) || defined(AARCH64)) 
   JavaThreadState thread_state() const           { return _thread_state; }
   void set_thread_state(JavaThreadState s)       { _thread_state = s;    }
 #else

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -1052,7 +1052,7 @@ class JavaThread: public Thread {
   address last_Java_pc(void)                     { return _anchor.last_Java_pc(); }
 
   // Safepoint support
-#if !(defined(PPC64) || defined(AARCH64))
+#if !(defined(PPC64) || defined(AARCH64)) || defined(RISCV64)
   JavaThreadState thread_state() const           { return _thread_state; }
   void set_thread_state(JavaThreadState s)       { _thread_state = s;    }
 #else

--- a/hotspot/src/share/vm/runtime/vframeArray.cpp
+++ b/hotspot/src/share/vm/runtime/vframeArray.cpp
@@ -477,7 +477,7 @@ void vframeArray::fill_in(JavaThread* thread,
   // Copy registers for callee-saved registers
   if (reg_map != NULL) {
     for(int i = 0; i < RegisterMap::reg_count; i++) {
-#if defined(AMD64) || defined(AARCH64)
+#if defined(AMD64) || defined(AARCH64) ||defined(RISCV64)
       // The register map has one entry for every int (32-bit value), so
       // 64-bit physical registers have two entries in the map, one for
       // each half.  Ignore the high halves of 64-bit registers, just like

--- a/hotspot/src/share/vm/utilities/macros.hpp
+++ b/hotspot/src/share/vm/utilities/macros.hpp
@@ -362,6 +362,22 @@
 #define NOT_AARCH64(code) code
 #endif
 
+#ifdef RISCV64
+#define RISCV64_ONLY(code) code
+#define NOT_RISCV64(code)
+#define NO_FLAG_REG
+#define NO_FLAGREG_ONLY(code) code
+#define HAS_FLAGREG_ONLY(code)
+#define NO_FLAGREG_ONLY_ARG(arg) arg,
+#else
+#define RISCV64_ONLY(code)
+#define NOT_RISCV64(code) code
+#define HAS_FLAG_REG
+#define NO_FLAGREG_ONLY(code)
+#define HAS_FLAGREG_ONLY(code) code
+#define NO_FLAGREG_ONLY_ARG(arg)
+#endif
+
 #ifdef SPARC
 #define SPARC_ONLY(code) code
 #define NOT_SPARC(code)


### PR DESCRIPTION
1.[Add print_instructions and extra_bang_size_in_bytes in os.hpp](https://github.com/zhangxiang-plct/jdk8u/commit/120943c6899ab56b7647a66d7082df56c19f445d)
2.[Add UseAESCTRIntrinsics and UseCRC32CIntrinsics in globals.hpp](https://github.com/zhangxiang-plct/jdk8u/commit/30062e4b3570c07167362f8913e5f777a2a9d036)
3.[Add the defined RISCV64](https://github.com/zhangxiang-plct/jdk8u/commit/f9f13770d657e0857cebb083c16870ffffc5f01a) refered aarch64.
