### PR TITLE
Add condy_helper/iload_internal and delete nofast_iload

### DIFF
--- a/hotspot/src/share/vm/interpreter/templateTable.hpp
+++ b/hotspot/src/share/vm/interpreter/templateTable.hpp
@@ -96,6 +96,7 @@ class TemplateTable: AllStatic {
   enum Operation { add, sub, mul, div, rem, _and, _or, _xor, shl, shr, ushr };
   enum Condition { equal, not_equal, less, less_equal, greater, greater_equal };
   enum CacheByte { f1_byte = 1, f2_byte = 2 };  // byte_no codes
+  enum RewriteControl { may_rewrite, may_not_rewrite };  // control for fast code under CDS
 
  private:
   static bool            _is_initialized;        // true if TemplateTable has been initialized
@@ -163,7 +164,7 @@ class TemplateTable: AllStatic {
   static void wide_fload();
   static void wide_dload();
   static void wide_aload();
-
+  static void iload_internal(RewriteControl rc = may_rewrite);
   static void iaload();
   static void laload();
   static void faload();
@@ -300,7 +301,7 @@ class TemplateTable: AllStatic {
   static void getstatic(int byte_no);
   static void putstatic(int byte_no);
   static void pop_and_check_object(Register obj);
-
+  static void condy_helper(Label& Done);  // shared by ldc instances
   static void _new();
   static void newarray();
   static void anewarray();


### PR DESCRIPTION
1.[Add condy_helper/iload_internal and delete nofast_iload](https://github.com/zhangxiang-plct/jdk8u/commit/96845b35a6b35fab3c5c6f33ba9f6d19bc6c964e) due to nofast_iload be declared.
2.backedge_mask_offset() is in MethodData.
3.getfield_or_static/putfield_or_static need be fixed due to its argus are different from jdk8.