### PR TITLE
Fix sharedRuntime/templateInterpreterGenerator.hpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
@@ -30,16 +30,17 @@
 #include "code/debugInfoRec.hpp"
 #include "code/icBuffer.hpp"
 #include "code/vtableStubs.hpp"
-#include "interpreter/interp_masm.hpp"
+//#include "interpreter/interp_masm.hpp"
 #include "interpreter/interpreter.hpp"
-#include "logging/log.hpp"
+//#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/compiledICHolder.hpp"
-#include "runtime/safepointMechanism.hpp"
+#include "safepointMechanism_riscv64.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vframeArray.hpp"
 #include "utilities/align.hpp"
 #include "vmreg_riscv64.inline.hpp"
+#include "prims/jvmtiRedefineClassesTrace.hpp"
 #ifdef COMPILER1
 #include "c1/c1_Runtime1.hpp"
 #endif
@@ -1115,7 +1116,7 @@ static void gen_special_dispatch(MacroAssembler* masm,
   } else if (iid == vmIntrinsics::_invokeBasic) {
     has_receiver = true;
   } else {
-    fatal("unexpected intrinsic id %d", iid);
+    fatal(err_msg_res("unexpected intrinsic id %d", iid));
   }
 
   if (member_reg != noreg) {

--- a/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.cpp
@@ -477,7 +477,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   return entry;
 }
 
-address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
+address TemplateInterpreterGenerator::generate_deopt_entry_for_rv(TosState state,
                                                                int step,
                                                                address continuation) {
   address entry = __ pc();
@@ -582,7 +582,7 @@ void TemplateInterpreterGenerator::generate_counter_incr(Label* overflow,
                                      MethodCounters::invocation_counter_offset() +
                                      InvocationCounter::counter_offset());
     __ get_method_counters(xmethod, t1, done);
-    const Address mask(t1, in_bytes(MethodCounters::invoke_mask_offset()));
+    const Address mask(t1, in_bytes(MethodData::invoke_mask_offset()));
     __ increment_mask_and_jump(invocation_counter, increment, mask, t0, x11, false, overflow);
     __ bind(done);
   } else { // not TieredCompilation
@@ -821,12 +821,12 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
   __ sd(ProfileInterpreter ? t0 : zr, Address(sp, 6 * wordSize));
 
   // Get mirror and store it in the frame as GC root for this Method*
-#if INCLUDE_SHENANDOAHGC
+/*#if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {
     __ load_mirror(x28, xmethod);
     __ sd(x28, Address(sp, 4 * wordSize));
   } else
-#endif
+#endif*/
   {
     __ load_mirror(t0, xmethod);
     __ sd(t0, Address(sp, 4 * wordSize));

--- a/hotspot/src/share/vm/interpreter/templateInterpreterGenerator.hpp
+++ b/hotspot/src/share/vm/interpreter/templateInterpreterGenerator.hpp
@@ -57,7 +57,19 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   address generate_earlyret_entry_for(TosState state);
   address generate_deopt_entry_for(TosState state, int step);
   address generate_safept_entry_for(TosState state, address runtime_entry);
+  address generate_abstract_entry(void);
+  address generate_ArrayIndexOutOfBounds_handler();
+  address generate_Reference_get_entry();
+  address generate_CRC32_update_entry();
+  address generate_CRC32_updateBytes_entry(AbstractInterpreter::MethodKind kind);
+  address generate_CRC32C_updateBytes_entry(AbstractInterpreter::MethodKind kind);
+  address generate_deopt_entry_for_rv(TosState state, int step, address continuation = NULL);
+  address generate_native_entry(bool synchronized);
+  address generate_math_entry(AbstractInterpreter::MethodKind kind);
   void    generate_throw_exception();
+  void lock_method();
+  void bang_stack_shadow_pages(bool native_call);
+  address generate_normal_entry(bool synchronized);
 
   // entry point generator
 //   address generate_method_entry(AbstractInterpreter::MethodKind kind);
@@ -72,6 +84,8 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   void set_unimplemented(int i);
   void set_entry_points_for_all_bytes();
   void set_safepoints_for_all_bytes();
+  void generate_counter_incr(Label* overflow, Label* profile_method, Label* profile_method_continue);
+  void generate_counter_overflow(Label& continue_entry);
 
   // Helpers for generate_and_dispatch
   address generate_trace_code(TosState state)   PRODUCT_RETURN0;
@@ -80,6 +94,7 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   void histogram_bytecode_pair(Template* t)     PRODUCT_RETURN;
   void trace_bytecode(Template* t)              PRODUCT_RETURN;
   void stop_interpreter_at()                    PRODUCT_RETURN;
+  void generate_stack_overflow_check(void);
 
   void generate_all();
 

--- a/hotspot/src/share/vm/runtime/stubRoutines.hpp
+++ b/hotspot/src/share/vm/runtime/stubRoutines.hpp
@@ -404,6 +404,7 @@ class StubRoutines: AllStatic {
   static address dexp()                { return _dexp; }
   static address dpow()                { return _dpow; }
   static address dsin()                { return _dsin; }
+  static address dcos()                { return _dcos; }
   static double  intrinsic_log(double d) {
     assert(_intrinsic_log != NULL, "must be defined");
     return _intrinsic_log(d);


### PR DESCRIPTION
1.Fix the include in hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
2.Add functions in hotspot/src/share/vm/interpreter/templateInterpreterGenerator.hpp