### PR TITLE
0902 fix vm version

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/vm_version_ext_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/vm_version_ext_riscv64.cpp
@@ -25,7 +25,7 @@
 
 #include "memory/allocation.hpp"
 #include "memory/allocation.inline.hpp"
-#include "runtime/os.inline.hpp"
+//#include "runtime/os.inline.hpp"
 #include "vm_version_ext_riscv64.hpp"
 
 // VM_Version_Ext statics

--- a/hotspot/src/cpu/riscv64/vm/vm_version_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/vm_version_riscv64.cpp
@@ -32,7 +32,9 @@
 #include "utilities/macros.hpp"
 #include "vm_version_riscv64.hpp"
 
-#include OS_HEADER_INLINE(os)
+#ifdef TARGET_OS_FAMILY_linux
+# include "os_linux.inline.hpp"
+#endif
 
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
@@ -166,5 +168,10 @@ void VM_Version::get_c2_processor_features() {
 
 void VM_Version::initialize() {
   get_processor_features();
-  UNSUPPORTED_OPTION(CriticalJNINatives);
+    if (CriticalJNINatives) {
+    if (FLAG_IS_CMDLINE(CriticalJNINatives)) {
+      warning("CriticalJNINatives specified, but not supported in this VM");
+    }
+    FLAG_SET_DEFAULT(CriticalJNINatives, false);
+  }
 }

--- a/hotspot/src/cpu/riscv64/vm/vm_version_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/vm_version_riscv64.hpp
@@ -34,9 +34,11 @@ class VM_Version : public Abstract_VM_Version {
 public:
   // Initialization
   static void initialize();
+  static const char* cpu_features()           { return _features_str; }
 
 protected:
   static void get_processor_features();
+  static const char* _features_str;
 
 #ifdef COMPILER2
 private:

--- a/hotspot/src/share/vm/runtime/vm_version.cpp
+++ b/hotspot/src/share/vm/runtime/vm_version.cpp
@@ -201,7 +201,8 @@ const char* Abstract_VM_Version::jre_release_version() {
                  IA64_ONLY("ia64")               \
                  AMD64_ONLY("amd64")             \
                  AARCH64_ONLY("aarch64")         \
-                 SPARC_ONLY("sparc")
+                 SPARC_ONLY("sparc")             \
+                 RISCV64_ONLY("riscv64")
 #endif // ZERO
 #endif
 

--- a/hotspot/src/share/vm/runtime/vm_version.hpp
+++ b/hotspot/src/share/vm/runtime/vm_version.hpp
@@ -50,6 +50,7 @@ class Abstract_VM_Version: AllStatic {
   static int          _parallel_worker_threads;
   static bool         _parallel_worker_threads_initialized;
   static int          _reserve_for_allocation_prefetch;
+  static const char* _features_string;
 
   static unsigned int nof_parallel_worker_threads(unsigned int num,
                                                   unsigned int dem,


### PR DESCRIPTION
1.Fix some include in hotspot/src/cpu/riscv64/vm/vm_version_ext_riscv64.cpp//hotspot/src/cpu/riscv64/vm/vm_version_riscv64.cpp
2.Fix initialize in hotspot/src/cpu/riscv64/vm/vm_version_riscv64.cpp.
3.Add RISCV64 in hotspot/src/share/vm/runtime/vm_version.cpp