### PR TITLE
Add define(RISCV64)in os_posix.cpp and delete the is_first_C_frame in…

### DIFF
--- a/hotspot/src/os/posix/vm/os_posix.cpp
+++ b/hotspot/src/os/posix/vm/os_posix.cpp
@@ -73,7 +73,7 @@ void os::check_or_create_dump(void* exceptionRecord, void* contextRecord, char* 
   }
   VMError::report_coredump_status(buffer, success);
 }
-
+#if !defined(RISCV64) || defined(ZERO)
 int os::get_native_stack(address* stack, int frames, int toSkip) {
 #ifdef _NMT_NOINLINE_
   toSkip++;
@@ -104,7 +104,7 @@ int os::get_native_stack(address* stack, int frames, int toSkip) {
 
   return num_of_frames;
 }
-
+#endif
 
 bool os::unsetenv(const char* name) {
   assert(name != NULL, "Null pointer");

--- a/hotspot/src/os_cpu/linux_riscv64/vm/os_linux_riscv64.cpp
+++ b/hotspot/src/os_cpu/linux_riscv64/vm/os_linux_riscv64.cpp
@@ -217,7 +217,7 @@ NOINLINE frame os::current_frame() {
   }
 }
 
-bool os::is_first_C_frame(frame* fr) {
+/*bool os::is_first_C_frame(frame* fr) {
   // Load up sp, fp, sender sp and sender fp, check for reasonable values.
   // Check usp first, because if that's bad the other accessors may fault
   // on some architectures.  Ditto ufp second, etc.
@@ -263,7 +263,7 @@ bool os::is_first_C_frame(frame* fr) {
   }
 
   return false;
-}
+}*/
 
 int os::get_native_stack(address* stack, int frames, int toSkip) {
   int frame_idx = 0;


### PR DESCRIPTION
1.Add '!defined(RISCV64) || defined(ZERO)' in hotspot/src/os/posix/vm/os_posix.cpp to avoid error in ZERO.
2.Delete `bool os::is_first_C_frame(frame* fr)` in hotspot/src/os_cpu/linux_riscv64/vm/os_linux_riscv64.cpp due to this is declared in os.hpp.