### PR TITLE
0905 02 fix undefined symbol

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/barrierSetAssembler_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/barrierSetAssembler_riscv64.cpp
@@ -30,7 +30,7 @@
 #include "barrierSetAssembler_riscv64.hpp"
 #include "asm/macroAssembler.hpp"
 #include "globals_riscv64.hpp"
-
+BarrierSetRv* BarrierSetRv::_barrier_set = NULL;
 /*
 class BarrierSetAssembler;
 // This class provides the interface between a barrier implementation and

--- a/hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/compiledIC_riscv64.cpp
@@ -33,6 +33,19 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 
+void CompiledIC::cleanup_call_site(virtual_call_Relocation* call_site) {
+  // This call site might have become stale so inspect it carefully.
+  NativeCall* call = nativeCall_at(call_site->addr());
+  if (is_icholder_entry(call->destination())) {
+    NativeMovConstReg* value = nativeMovConstReg_at(call_site->cached_value());
+    InlineCacheBuffer::queue_for_release((CompiledICHolder*)value->data());
+  }
+}
+/*bool CompiledIC::is_icholder_call_site(virtual_call_Relocation* call_site) {
+  // This call site might have become stale so inspect it carefully.
+  NativeCall* call = nativeCall_at(call_site->addr());
+  return is_icholder_entry(call->destination());
+}*/
 // ----------------------------------------------------------------------------
 
 #define __ _masm.

--- a/hotspot/src/cpu/riscv64/vm/frame_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/frame_riscv64.cpp
@@ -298,7 +298,9 @@ void frame::patch_pc(Thread* thread, address pc) {
     _pc = pc;
   }
 }
-
+void frame::pd_gc_epilog() {
+  // nothing done here now
+}
 bool frame::is_interpreted_frame() const  {
   return Interpreter::contains(pc());
 }

--- a/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
@@ -506,10 +506,10 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
 
   Label safepoint;
   address* const safepoint_table = Interpreter::safept_table(state);
-  bool needs_thread_local_poll = generate_poll &&
+   /* bool needs_thread_local_poll = generate_poll &&
     SafepointMechanism::uses_thread_local_poll() && table != safepoint_table;
 
-  /*if (needs_thread_local_poll) {
+if (needs_thread_local_poll) {
     NOT_PRODUCT(block_comment("Thread-local Safepoint poll"));
     ld(t1, Address(xthread, Thread::polling_page_offset()));
     andi(t1, t1, 1 << exact_log2(SafepointMechanism::poll_bit()));
@@ -528,14 +528,14 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   ld(t1, Address(t1));
   jr(t1);
 
-  if (needs_thread_local_poll) {
+ /* if (needs_thread_local_poll) {
     bind(safepoint);
     la(t1, ExternalAddress((address)safepoint_table));
     slli(Rs, Rs, 3);
     add(t1, t1, Rs);
     ld(t1, Address(t1));
     jr(t1);
-  }
+  }*/
 }
 
 void InterpreterMacroAssembler::dispatch_only(TosState state, bool generate_poll, Register Rs) {

--- a/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.cpp
@@ -2001,7 +2001,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
          "caller must be same register for non-constant itable index as for method");
 
   // Compute start of first itableOffsetEntry (which is at the end of the vtable).
-  int vtable_base = in_bytes(Klass::vtable_start_offset());
+  int vtable_base = InstanceKlass::vtable_start_offset() * wordSize;
   int itentry_off = itableMethodEntry::method_offset_in_bytes();
   int scan_step   = itableOffsetEntry::size() * wordSize;
   int vte_size    = vtableEntry::size_in_bytes();
@@ -2055,7 +2055,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 void MacroAssembler::lookup_virtual_method(Register recv_klass,
                                            RegisterOrConstant vtable_index,
                                            Register method_result) {
-  const int base = in_bytes(Klass::vtable_start_offset());
+  const int base = InstanceKlass::vtable_start_offset() * wordSize;
   assert(vtableEntry::size() * wordSize == 8,
          "adjust the scaling in the code below");
   int vtable_offset_in_bytes = base + vtableEntry::method_offset_in_bytes();
@@ -2134,17 +2134,17 @@ void MacroAssembler::serialize_memory(Register thread, Register tmp1, Register t
 }
 
 void MacroAssembler::safepoint_poll(Label& slow_path) {
-  if (SafepointMechanism::uses_thread_local_poll()) {
-    ld(t1, Address(xthread, Thread::polling_page_offset()));
-    andi(t0, t1, SafepointMechanism::poll_bit());
-    bnez(t0, slow_path);
-  } else {
+ // if (SafepointMechanism::uses_thread_local_poll()) {
+  //  ld(t1, Address(xthread, Thread::polling_page_offset()));
+  //  andi(t0, t1, SafepointMechanism::poll_bit());
+  //  bnez(t0, slow_path);
+  //} else {
     int32_t offset = 0;
     la_patchable(t0, ExternalAddress(SafepointSynchronize::address_of_state()), offset);
     lwu(t0, Address(t0, offset));
     assert(SafepointSynchronize::_not_synchronized == 0, "rewrite this code");
     bnez(t0, slow_path);
-  }
+ // }
 }
 
 // Just like safepoint_poll, but use an acquiring load for thread-
@@ -2159,7 +2159,7 @@ void MacroAssembler::safepoint_poll(Label& slow_path) {
 // This is to avoid a race when we're in a native->Java transition
 // racing the code which wakes up from a safepoint.
 //
-void MacroAssembler::safepoint_poll_acquire(Label& slow_path) {
+/*void MacroAssembler::safepoint_poll_acquire(Label& slow_path) {
   if (SafepointMechanism::uses_thread_local_poll()) {
     membar(MacroAssembler::AnyAny);
     ld(t1, Address(xthread, Thread::polling_page_offset()));
@@ -2169,7 +2169,7 @@ void MacroAssembler::safepoint_poll_acquire(Label& slow_path) {
   } else {
     safepoint_poll(slow_path);
   }
-}
+}*/
 
 void MacroAssembler::cmpxchgptr(Register oldv, Register newv, Register addr, Register tmp,
                                 Label &succeed, Label *fail) {
@@ -3015,13 +3015,13 @@ void MacroAssembler::reserved_stack_check() {
 
 // Move the address of the polling page into dest.
 void MacroAssembler::get_polling_page(Register dest, address page, int32_t &offset, relocInfo::relocType rtype) {
-  if (SafepointMechanism::uses_thread_local_poll()) {
-    ld(dest, Address(xthread, Thread::polling_page_offset()));
-  } else {
+//  if (SafepointMechanism::uses_thread_local_poll()) {
+  //  ld(dest, Address(xthread, Thread::polling_page_offset()));
+//  } else {
     unsigned long align = (uintptr_t)page & 0xfff;
     assert(align == 0, "polling page must be page aligned");
     la_patchable(dest, Address(page, rtype), offset);
-  }
+//  }
 }
 
 // Move the address of the polling page into dest.

--- a/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.hpp
@@ -42,7 +42,7 @@ class MacroAssembler: public Assembler {
   virtual ~MacroAssembler() {}
 
   void safepoint_poll(Label& slow_path);
-  void safepoint_poll_acquire(Label& slow_path);
+ // void safepoint_poll_acquire(Label& slow_path);
 
   // Alignment
   void align(int modulus);

--- a/hotspot/src/cpu/riscv64/vm/relocInfo_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/relocInfo_riscv64.cpp
@@ -109,6 +109,11 @@ void poll_Relocation::fix_relocation_after_move(const CodeBuffer* src, CodeBuffe
     MacroAssembler::pd_patch_instruction_size(addr(), MacroAssembler::target_addr_for_insn(old_addr));
   }
 }
-
+void poll_return_Relocation::fix_relocation_after_move(const CodeBuffer* src, CodeBuffer* dest)  {
+  if (NativeInstruction::maybe_cpool_ref(addr())) {
+    address old_addr = old_addr_for(addr(), src, dest);
+    MacroAssembler::pd_patch_instruction_size(addr(), MacroAssembler::target_addr_for_insn(old_addr));
+  }
+}
 void metadata_Relocation::pd_fix_value(address x) {
 }

--- a/hotspot/src/cpu/riscv64/vm/safepointMechanism_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/safepointMechanism_riscv64.hpp
@@ -36,10 +36,10 @@ class SafepointMechanism : public AllStatic {
     _global_page_poll,
     _thread_local_poll
   };
-  static PollingType _polling_type;
+  //static PollingType _polling_type;
   static void* _poll_armed_value;
   static void* _poll_disarmed_value;
-  static void set_uses_thread_local_poll()            { _polling_type     = _thread_local_poll; }
+ //static void set_uses_thread_local_poll()            { _polling_type     = _thread_local_poll; }
 
   static void* poll_armed_value()                     { return _poll_armed_value; }
   static void* poll_disarmed_value()                  { return _poll_disarmed_value; }
@@ -62,8 +62,8 @@ class SafepointMechanism : public AllStatic {
 public:
   static intptr_t poll_bit() { return _poll_bit; }
 
-  static bool uses_global_page_poll() { return _polling_type == _global_page_poll; }
-  static bool uses_thread_local_poll() { return _polling_type == _thread_local_poll; }
+  //static bool uses_global_page_poll() { return _polling_type == _global_page_poll; }
+  //static bool uses_thread_local_poll() { return _polling_type == _thread_local_poll; }
 
   static bool supports_thread_local_poll() {
 #ifdef THREAD_LOCAL_POLL

--- a/hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
@@ -1182,12 +1182,12 @@ static void gen_special_dispatch(MacroAssembler* masm,
 //    return to caller
 //
 nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
-                                                const methodHandle& method,
+                                                 methodHandle method,
                                                 int compile_id,
                                                 BasicType* in_sig_bt,
                                                 VMRegPair* in_regs,
-                                                BasicType ret_type,
-                                                address critical_entry) {
+                                                BasicType ret_type
+                                                ) {
   assert_cond(masm != NULL && in_sig_bt != NULL && in_regs != NULL);
   if (method->is_method_handle_intrinsic()) {
     vmIntrinsics::ID iid = method->intrinsic_id();
@@ -1214,7 +1214,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
                                        (OopMapSet*)NULL);
   }
   bool is_critical_native = true;
-  address native_func = critical_entry;
+  address native_func = method->critical_native_function();
   if (native_func == NULL) {
     native_func = method->native_function();
     is_critical_native = false;
@@ -1800,13 +1800,13 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   // check for safepoint operation in progress and/or pending suspend requests
-  Label safepoint_in_progress, safepoint_in_progress_done;
+ /* Label safepoint_in_progress, safepoint_in_progress_done;
   {
     __ safepoint_poll_acquire(safepoint_in_progress);
     __ lwu(t0, Address(xthread, JavaThread::suspend_flags_offset()));
     __ bnez(t0, safepoint_in_progress);
     __ bind(safepoint_in_progress_done);
-  }
+  }*/
 
   // change thread state
   Label after_transition;
@@ -1998,7 +1998,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   __ j(reguard_done);
 
   // SLOW PATH safepoint
-  {
+  /*{
     __ block_comment("safepoint {");
     __ bind(safepoint_in_progress);
 
@@ -2029,7 +2029,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     __ j(safepoint_in_progress_done);
     __ block_comment("} safepoint");
-  }
+  }*/
 
   // SLOW PATH dtrace support
   {
@@ -2683,7 +2683,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
   __ bind(noException);
 
   Label no_adjust, bail;
-  if (SafepointMechanism::uses_thread_local_poll() && !cause_return) {
+  /*if (SafepointMechanism::uses_thread_local_poll() && !cause_return) {
     // If our stashed return pc was modified by the runtime we avoid touching it
     __ ld(t0, Address(fp, wordSize));
     __ bne(x18, t0, no_adjust);
@@ -2706,7 +2706,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
     // Adjust return pc forward to step over the safepoint poll instruction
     __ add(x18, x18, NativeInstruction::instruction_size);
     __ sd(x18, Address(fp, wordSize));
-  }
+  }*/
 
   __ bind(no_adjust);
   // Normal exit, restore registers and exit.

--- a/hotspot/src/cpu/riscv64/vm/vm_version_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/vm_version_riscv64.cpp
@@ -78,6 +78,7 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
   ~VM_Version_StubGenerator() {}
 };
 
+//int VM_Version::_features_str;
 void VM_Version::get_processor_features() {
   if (FLAG_IS_DEFAULT(UseFMA)) {
     FLAG_SET_DEFAULT(UseFMA, true);

--- a/hotspot/src/cpu/riscv64/vm/vmreg_riscv64.inline.hpp
+++ b/hotspot/src/cpu/riscv64/vm/vmreg_riscv64.inline.hpp
@@ -27,6 +27,16 @@
 #ifndef CPU_RISCV64_VM_VMREG_RISCV64_INLINE_HPP
 #define CPU_RISCV64_VM_VMREG_RISCV64_INLINE_HPP
 
+inline VMReg RegisterImpl::as_VMReg() {
+  if( this==noreg ) return VMRegImpl::Bad();
+  return VMRegImpl::as_VMReg(encoding() << 1 );
+}
+
+inline VMReg FloatRegisterImpl::as_VMReg() {
+  return VMRegImpl::as_VMReg((encoding() << 1) + ConcreteRegisterImpl::max_gpr);
+}
+
+
 inline bool VMRegImpl::is_Register() {
   return (unsigned int) value() < (unsigned int) ConcreteRegisterImpl::max_gpr;
 }

--- a/hotspot/src/cpu/riscv64/vm/vtableStubs_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/vtableStubs_riscv64.cpp
@@ -135,7 +135,16 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
   __ jr(t0);
 
   masm->flush();
-  bookkeeping(masm, tty, s, npe_addr, ame_addr, true, vtable_index, slop_bytes, 0);
+ // bookkeeping(masm, tty, s, npe_addr, ame_addr, true, vtable_index, slop_bytes, 0);
+   if (PrintMiscellaneous && (WizardMode || Verbose)) {
+    tty->print_cr("vtable #%d at "PTR_FORMAT"[%d] left over: %d",
+                  vtable_index, p2i(s->entry_point()),
+                  (int)(s->code_end() - s->entry_point()),
+                  (int)(s->code_end() - __ pc()));
+  }
+  guarantee(__ pc() <= s->code_end(), "overflowed buffer");
+
+  s->set_exception_points(npe_addr, ame_addr);
 
   return s;
 }
@@ -244,11 +253,21 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // We force resolving of the call site by jumping to the "handle
   // wrong method" stub, and so let the interpreter runtime do all the
   // dirty work.
-  assert(SharedRuntime::get_handle_wrong_method_stub() != NULL, "check initialization order");
+ assert(SharedRuntime::get_handle_wrong_method_stub() != NULL, "check initialization order");
   __ far_jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub()));
 
   masm->flush();
-  bookkeeping(masm, tty, s, npe_addr, ame_addr, false, itable_index, slop_bytes, 0);
+  /* bookkeeping(masm, tty, s, npe_addr, ame_addr, false, itable_index, slop_bytes, 0);*/
+  if (PrintMiscellaneous && (WizardMode || Verbose)) {
+    tty->print_cr("itable #%d at "PTR_FORMAT"[%d] left over: %d",
+                  itable_index, p2i(s->entry_point()),
+                  (int)(s->code_end() - s->entry_point()),
+                  (int)(s->code_end() - __ pc()));
+  }
+  guarantee(__ pc() <= s->code_end(), "overflowed buffer");
+
+  s->set_exception_points(npe_addr, ame_addr);
+
 
   return s;
 }

--- a/hotspot/src/os_cpu/linux_riscv64/vm/threadLS_linux_riscv64.cpp
+++ b/hotspot/src/os_cpu/linux_riscv64/vm/threadLS_linux_riscv64.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "runtime/threadLocalStorage.hpp"
+#include "runtime/thread.inline.hpp"
+
+void ThreadLocalStorage::generate_code_for_get_thread() {
+    // nothing we can do here for user-level thread
+}
+
+void ThreadLocalStorage::pd_init() {
+}
+
+__thread Thread *riscv64_currentThread;
+
+void ThreadLocalStorage::pd_set_thread(Thread* thread) {
+  os::thread_local_storage_at_put(ThreadLocalStorage::thread_index(), thread);
+  riscv64_currentThread = thread;
+}

--- a/hotspot/src/share/vm/classfile/javaClasses.cpp
+++ b/hotspot/src/share/vm/classfile/javaClasses.cpp
@@ -2749,8 +2749,10 @@ int java_lang_invoke_MemberName::_flags_offset;
 int java_lang_invoke_MemberName::_vmtarget_offset;
 int java_lang_invoke_MemberName::_vmloader_offset;
 int java_lang_invoke_MemberName::_vmindex_offset;
+int java_lang_invoke_MemberName::_method_offset;
 
 int java_lang_invoke_LambdaForm::_vmentry_offset;
+int java_lang_invoke_ResolvedMethodName::_vmtarget_offset;
 
 void java_lang_invoke_MethodHandle::compute_offsets() {
   Klass* klass_oop = SystemDictionary::MethodHandle_klass();

--- a/hotspot/src/share/vm/code/codeBlob.hpp
+++ b/hotspot/src/share/vm/code/codeBlob.hpp
@@ -119,6 +119,8 @@ class CodeBlob VALUE_OBJ_CLASS_SPEC {
 
   // Casting
   nmethod* as_nmethod_or_null()                  { return is_nmethod() ? (nmethod*) this : NULL; }
+ // nmethod* as_compiled_method()                  { assert(is_compiled(), "must be compiled"); return (nmethod*) this; }
+
 
   // Boundaries
   address    header_begin() const                { return (address)    this; }

--- a/hotspot/src/share/vm/code/compiledIC.cpp
+++ b/hotspot/src/share/vm/code/compiledIC.cpp
@@ -323,7 +323,11 @@ bool CompiledIC::is_call_to_interpreted() const {
   }
   return is_call_to_interpreted;
 }
-
+bool CompiledIC::is_icholder_call_site(virtual_call_Relocation* call_site) {
+  // This call site might have become stale so inspect it carefully.
+  NativeCall* call = nativeCall_at(call_site->addr());
+  return is_icholder_entry(call->destination());
+}
 
 void CompiledIC::set_to_clean(bool in_use) {
   assert(SafepointSynchronize::is_at_safepoint() || CompiledIC_lock->is_locked() , "MT-unsafe call");

--- a/hotspot/src/share/vm/code/compiledIC.hpp
+++ b/hotspot/src/share/vm/code/compiledIC.hpp
@@ -326,7 +326,7 @@ class CompiledStaticCall: public NativeCall {
   friend CompiledStaticCall* compiledStaticCall_at(Relocation* call_site);
 
   // Code
-#if (defined(AARCH64) || defined(RISCV64) )&& !defined(ZERO)
+#if (defined(AARCH64) || defined(RISCV64))&& !defined(ZERO)
   static address emit_to_interp_stub(CodeBuffer &cbuf, address mark);
 #else
   static address emit_to_interp_stub(CodeBuffer &cbuf);

--- a/hotspot/src/share/vm/code/nmethod.hpp
+++ b/hotspot/src/share/vm/code/nmethod.hpp
@@ -807,6 +807,7 @@ class nmethodLocker : public StackObj {
     _nm = new_nm;
     lock_nmethod(_nm);
   }
+
 };
 
 #endif // SHARE_VM_CODE_NMETHOD_HPP

--- a/hotspot/src/share/vm/code/vtableStubs.cpp
+++ b/hotspot/src/share/vm/code/vtableStubs.cpp
@@ -82,7 +82,13 @@ void VtableStub::print_on(outputStream* st) const {
              index(), receiver_location(), code_begin(), code_end());
 }
 
-
+int VtableStub::pd_code_size_limit(bool is_vtable_stub) {
+  if (TraceJumps || DebugVtables || CountCompiledCalls || VerifyOops) {
+    return 1000;
+  }
+  int size = is_vtable_stub ? 60 : 192; // Plain + safety
+  return size;
+  }
 // -----------------------------------------------------------------------------------------
 // Implementation of VtableStubs
 //

--- a/hotspot/src/share/vm/code/vtableStubs.hpp
+++ b/hotspot/src/share/vm/code/vtableStubs.hpp
@@ -122,9 +122,9 @@ class VtableStubs : AllStatic {
   static void        enter             (bool is_vtable_stub, int vtable_index, VtableStub* s);
   static inline uint hash              (bool is_vtable_stub, int vtable_index);
   static address     find_stub         (bool is_vtable_stub, int vtable_index);
-  static void        bookkeeping(MacroAssembler* masm, outputStream* out, VtableStub* s,
-                                 address npe_addr, address ame_addr,   bool is_vtable_stub,
-                                 int     index,    int     slop_bytes, int  index_dependent_slop);
+  //static void        bookkeeping(MacroAssembler* masm, outputStream* out, VtableStub* s,
+  //                               address npe_addr, address ame_addr,   bool is_vtable_stub,
+  //                               int     index,    int     slop_bytes, int  index_dependent_slop);
  public:
   static address     find_vtable_stub(int vtable_index) { return find_stub(true,  vtable_index); }
   static address     find_itable_stub(int itable_index) { return find_stub(false, itable_index); }

--- a/hotspot/src/share/vm/interpreter/interpreterRuntime.cpp
+++ b/hotspot/src/share/vm/interpreter/interpreterRuntime.cpp
@@ -224,6 +224,13 @@ IRT_ENTRY(void, InterpreterRuntime::multianewarray(JavaThread* thread, jint* fir
   thread->set_vm_result(obj);
 IRT_END
 
+IRT_ENTRY(void, InterpreterRuntime::throw_AbstractMethodErrorWithMethod(JavaThread* thread,
+                                                                        Method* missingMethod))
+  ResourceMark rm(thread);
+  assert(missingMethod != NULL, "sanity");
+  methodHandle m(thread, missingMethod);
+  LinkResolver::throw_abstract_method_error(m, THREAD);
+IRT_END
 
 IRT_ENTRY(void, InterpreterRuntime::register_finalizer(JavaThread* thread, oopDesc* obj))
   assert(obj->is_oop(), "must be a valid oop");

--- a/hotspot/src/share/vm/interpreter/linkResolver.cpp
+++ b/hotspot/src/share/vm/interpreter/linkResolver.cpp
@@ -1681,6 +1681,43 @@ void LinkResolver::resolve_dynamic_call(CallInfo& result,
   wrap_invokedynamic_exception(CHECK);
 }
 
+// Selected method is abstract.
+void LinkResolver::throw_abstract_method_error(const methodHandle& resolved_method,
+                                               const methodHandle& selected_method,
+                                               Klass *recv_klass, TRAPS) {
+  Klass *resolved_klass = resolved_method->method_holder();
+  ResourceMark rm(THREAD);
+  stringStream ss;
+
+  if (recv_klass != NULL) {
+    ss.print("Receiver class %s does not define or inherit an "
+             "implementation of the",
+             recv_klass->external_name());
+  } else {
+    ss.print("Missing implementation of");
+  }
+
+  assert(resolved_method.not_null(), "Sanity");
+  ss.print(" resolved method '%s%s",
+           resolved_method->is_abstract() ? "abstract " : "",
+           resolved_method->is_private()  ? "private "  : "");
+  resolved_method->signature()->print_as_signature_external_return_type(&ss);
+  ss.print(" %s(", resolved_method->name()->as_C_string());
+  resolved_method->signature()->print_as_signature_external_parameters(&ss);
+  ss.print(")' of %s %s.",
+           resolved_klass->external_kind(),
+           resolved_klass->external_name());
+
+  if (selected_method.not_null() && !(resolved_method == selected_method)) {
+    ss.print(" Selected method is '%s%s",
+             selected_method->is_abstract() ? "abstract " : "",
+             selected_method->is_private()  ? "private "  : "");
+    selected_method->print_external_name(&ss);
+    ss.print("'.");
+  }
+
+  THROW_MSG(vmSymbols::java_lang_AbstractMethodError(), ss.as_string());
+}
 //------------------------------------------------------------------------------------------------------------------------
 #ifndef PRODUCT
 

--- a/hotspot/src/share/vm/interpreter/linkResolver.hpp
+++ b/hotspot/src/share/vm/interpreter/linkResolver.hpp
@@ -206,6 +206,19 @@ class LinkResolver: AllStatic {
   static void resolve_invokehandle   (CallInfo& result,              constantPoolHandle pool, int index, TRAPS);
 
   static void resolve_invoke         (CallInfo& result, Handle recv, constantPoolHandle pool, int index, Bytecodes::Code byte, TRAPS);
+public:
+  // Only resolved method known.
+  static void throw_abstract_method_error(const methodHandle& resolved_method, TRAPS) {
+    throw_abstract_method_error(resolved_method, NULL, NULL, CHECK);
+  }
+  // Resolved method and receiver klass know.
+  static void throw_abstract_method_error(const methodHandle& resolved_method, Klass *recv_klass, TRAPS) {
+    throw_abstract_method_error(resolved_method, NULL, recv_klass, CHECK);
+  }
+  // Selected method is abstract.
+  static void throw_abstract_method_error(const methodHandle& resolved_method,
+                                          const methodHandle& selected_method,
+                                          Klass *recv_klass, TRAPS);
 };
 
 #endif // SHARE_VM_INTERPRETER_LINKRESOLVER_HPP

--- a/hotspot/src/share/vm/interpreter/templateInterpreterGenerator.hpp
+++ b/hotspot/src/share/vm/interpreter/templateInterpreterGenerator.hpp
@@ -39,8 +39,8 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
 
   // shared code sequences
   // Converter for native abi result to tosca result
-  address generate_result_handler_for(BasicType type);
-  address generate_slow_signature_handler();
+  //address generate_result_handler_for(BasicType type);
+  //address generate_slow_signature_handler();
   address generate_error_exit(const char* msg);
   address generate_StackOverflowError_handler();
   address generate_exception_handler(const char* name, const char* message) {
@@ -58,18 +58,18 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   address generate_deopt_entry_for(TosState state, int step);
   address generate_safept_entry_for(TosState state, address runtime_entry);
   address generate_abstract_entry(void);
-  address generate_ArrayIndexOutOfBounds_handler();
-  address generate_Reference_get_entry();
+  //address generate_ArrayIndexOutOfBounds_handler();
+  //address generate_Reference_get_entry();
   address generate_CRC32_update_entry();
-  address generate_CRC32_updateBytes_entry(AbstractInterpreter::MethodKind kind);
+  //address generate_CRC32_updateBytes_entry(AbstractInterpreter::MethodKind kind);
   address generate_CRC32C_updateBytes_entry(AbstractInterpreter::MethodKind kind);
-  address generate_deopt_entry_for_rv(TosState state, int step, address continuation = NULL);
+  //address generate_deopt_entry_for(TosState state, int step);
   address generate_native_entry(bool synchronized);
-  address generate_math_entry(AbstractInterpreter::MethodKind kind);
+  //address generate_math_entry(AbstractInterpreter::MethodKind kind);
   void    generate_throw_exception();
-  void lock_method();
+ // void lock_method();
   void bang_stack_shadow_pages(bool native_call);
-  address generate_normal_entry(bool synchronized);
+  //address generate_normal_entry(bool synchronized);
 
   // entry point generator
 //   address generate_method_entry(AbstractInterpreter::MethodKind kind);
@@ -85,7 +85,7 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   void set_entry_points_for_all_bytes();
   void set_safepoints_for_all_bytes();
   void generate_counter_incr(Label* overflow, Label* profile_method, Label* profile_method_continue);
-  void generate_counter_overflow(Label& continue_entry);
+  //void generate_counter_overflow(Label& continue_entry);
 
   // Helpers for generate_and_dispatch
   address generate_trace_code(TosState state)   PRODUCT_RETURN0;

--- a/hotspot/src/share/vm/interpreter/templateTable.hpp
+++ b/hotspot/src/share/vm/interpreter/templateTable.hpp
@@ -180,6 +180,7 @@ class TemplateTable: AllStatic {
   static void dload(int n);
   static void aload(int n);
   static void aload_0();
+  static void aload_0_internal(RewriteControl rc);
 
   static void istore();
   static void lstore();

--- a/hotspot/src/share/vm/memory/universe.cpp
+++ b/hotspot/src/share/vm/memory/universe.cpp
@@ -121,6 +121,7 @@ oop Universe::_out_of_memory_error_class_metaspace    = NULL;
 oop Universe::_out_of_memory_error_array_size         = NULL;
 oop Universe::_out_of_memory_error_gc_overhead_limit  = NULL;
 oop Universe::_out_of_memory_error_realloc_objects    = NULL;
+oop Universe::_delayed_stack_overflow_error_message   = NULL;
 objArrayOop Universe::_preallocated_out_of_memory_error_array = NULL;
 volatile jint Universe::_preallocated_out_of_memory_error_avail_count = 0;
 bool Universe::_verify_in_progress                    = false;
@@ -130,6 +131,7 @@ oop Universe::_arithmetic_exception_instance          = NULL;
 oop Universe::_virtual_machine_error_instance         = NULL;
 oop Universe::_vm_exception                           = NULL;
 oop Universe::_allocation_context_notification_obj    = NULL;
+oop Universe::_the_null_sentinel                      = NULL;
 
 Array<int>* Universe::_the_empty_int_array            = NULL;
 Array<u2>* Universe::_the_empty_short_array           = NULL;

--- a/hotspot/src/share/vm/memory/universe.hpp
+++ b/hotspot/src/share/vm/memory/universe.hpp
@@ -158,6 +158,8 @@ class Universe: AllStatic {
   static oop          _out_of_memory_error_array_size;
   static oop          _out_of_memory_error_gc_overhead_limit;
   static oop          _out_of_memory_error_realloc_objects;
+  // preallocated cause message for delayed StackOverflowError
+  static oop          _delayed_stack_overflow_error_message;
 
   static Array<int>*       _the_empty_int_array;    // Canonicalized int array
   static Array<u2>*        _the_empty_short_array;  // Canonicalized short array
@@ -331,6 +333,8 @@ class Universe: AllStatic {
   static oop out_of_memory_error_array_size()         { return gen_out_of_memory_error(_out_of_memory_error_array_size); }
   static oop out_of_memory_error_gc_overhead_limit()  { return gen_out_of_memory_error(_out_of_memory_error_gc_overhead_limit);  }
   static oop out_of_memory_error_realloc_objects()    { return gen_out_of_memory_error(_out_of_memory_error_realloc_objects);  }
+  static oop delayed_stack_overflow_error_message()   { return _delayed_stack_overflow_error_message; }
+
 
   // Accessors needed for fast allocation
   static Klass** boolArrayKlassObj_addr()           { return &_boolArrayKlassObj;   }

--- a/hotspot/src/share/vm/oops/klass.cpp
+++ b/hotspot/src/share/vm/oops/klass.cpp
@@ -621,6 +621,11 @@ const char* Klass::signature_name() const {
   if (name() == NULL)  return "<unknown>";
   return name()->as_C_string();
 }
+const char* Klass::external_kind() const {
+  if (is_interface()) return "interface";
+  if (is_abstract()) return "abstract class";
+  return "class";
+}
 
 // Unless overridden, modifier_flags is 0.
 jint Klass::compute_modifier_flags(TRAPS) const {

--- a/hotspot/src/share/vm/oops/klass.hpp
+++ b/hotspot/src/share/vm/oops/klass.hpp
@@ -529,6 +529,7 @@ protected:
   // For classes, this returns the name with a leading 'L' and a trailing ';'
   //     and the package separators as '/'.
   virtual const char* signature_name() const;
+  const char* external_kind() const;
 
   // garbage collection support
   virtual void oop_follow_contents(oop obj) = 0;

--- a/hotspot/src/share/vm/oops/method.cpp
+++ b/hotspot/src/share/vm/oops/method.cpp
@@ -239,7 +239,15 @@ void Method::mask_for(int bci, InterpreterOopMap* mask) {
   return;
 }
 
-
+void Method::print_external_name(outputStream *os) const {
+  print_external_name(os, constants()->pool_holder(), name(), signature());
+}
+void Method::print_external_name(outputStream *os, Klass* klass, Symbol* method_name, Symbol* signature) {
+  signature->print_as_signature_external_return_type(os);
+  os->print(" %s.%s(", klass->external_name(), method_name->as_C_string());
+  signature->print_as_signature_external_parameters(os);
+  os->print(")");
+}
 int Method::bci_from(address bcp) const {
 #ifdef ASSERT
   { ResourceMark rm;

--- a/hotspot/src/share/vm/oops/method.hpp
+++ b/hotspot/src/share/vm/oops/method.hpp
@@ -212,6 +212,9 @@ class Method : public Metadata {
   // area if a buffer is not provided by the caller.
   char* name_and_sig_as_C_string() const;
   char* name_and_sig_as_C_string(char* buf, int size) const;
+  void  print_external_name(outputStream *os) const;
+  static void  print_external_name(outputStream *os, Klass* klass, Symbol* method_name, Symbol* signature);
+
 
   // Static routine in the situations we don't have a Method*
   static char* name_and_sig_as_C_string(Klass* klass, Symbol* method_name, Symbol* signature);

--- a/hotspot/src/share/vm/oops/symbol.cpp
+++ b/hotspot/src/share/vm/oops/symbol.cpp
@@ -205,7 +205,64 @@ const char* Symbol::as_klass_external_name() const {
   }
   return str;
 }
+static void print_class(outputStream *os, char *class_str, int len) {
+  for (int i = 0; i < len; ++i) {
+    if (class_str[i] == '/') {
+      os->put('.');
+    } else {
+      os->put(class_str[i]);
+    }
+  }
+}
 
+static void print_array(outputStream *os, char *array_str, int len) {
+  int dimensions = 0;
+  for (int i = 0; i < len; ++i) {
+    if (array_str[i] == '[') {
+      dimensions++;
+    } else if (array_str[i] == 'L') {
+      // Expected format: L<type name>;. Skip 'L' and ';' delimiting the type name.
+      print_class(os, array_str+i+1, len-i-2);
+      break;
+    } else {
+      os->print("%s", type2name(char2type(array_str[i])));
+    }
+  }
+  for (int i = 0; i < dimensions; ++i) {
+    os->print("[]");
+  }
+}
+void Symbol::print_as_signature_external_return_type(outputStream *os) {
+  for (SignatureStream ss(this); !ss.is_done(); ss.next()) {
+    if (ss.at_return_type()) {
+      if (ss.is_array()) {
+        print_array(os, (char*)ss.raw_bytes(), (int)ss.raw_length());
+      } else if (ss.is_object()) {
+        // Expected format: L<type name>;. Skip 'L' and ';' delimiting the class name.
+        print_class(os, (char*)ss.raw_bytes()+1, (int)ss.raw_length()-2);
+      } else {
+        os->print("%s", type2name(ss.type()));
+      }
+    }
+  }
+}
+
+void Symbol::print_as_signature_external_parameters(outputStream *os) {
+  bool first = true;
+  for (SignatureStream ss(this); !ss.is_done(); ss.next()) {
+    if (ss.at_return_type()) break;
+    if (!first) { os->print(", "); }
+    if (ss.is_array()) {
+      print_array(os, (char*)ss.raw_bytes(), (int)ss.raw_length());
+    } else if (ss.is_object()) {
+      // Skip 'L' and ';'.
+      print_class(os, (char*)ss.raw_bytes()+1, (int)ss.raw_length()-2);
+    } else {
+      os->print("%s", type2name(ss.type()));
+    }
+    first = false;
+  }
+}
 // Alternate hashing for unbalanced symbol tables.
 unsigned int Symbol::new_hash(juint seed) {
   ResourceMark rm;

--- a/hotspot/src/share/vm/oops/symbol.hpp
+++ b/hotspot/src/share/vm/oops/symbol.hpp
@@ -213,6 +213,14 @@ class Symbol : private SymbolBase {
   // See Klass::external_name()
   const char* as_klass_external_name() const;
   const char* as_klass_external_name(char* buf, int size) const;
+    // Treating the symbol as a signature, print the return
+  // type to the outputStream. Prints external names as 'double' or
+  // 'java.lang.Object[][]'.
+  void print_as_signature_external_return_type(outputStream *os);
+  // Treating the symbol as a signature, print the parameter types
+  // seperated by ', ' to the outputStream.  Prints external names as
+  //  'double' or 'java.lang.Object[][]'.
+  void print_as_signature_external_parameters(outputStream *os);
 
   // Printing
   void print_symbol_on(outputStream* st = NULL) const;

--- a/hotspot/src/share/vm/runtime/os.cpp
+++ b/hotspot/src/share/vm/runtime/os.cpp
@@ -103,7 +103,10 @@ int os::snprintf(char* buf, size_t len, const char* fmt, ...) {
   va_end(args);
   return result;
 }
-
+void os::print_instructions(outputStream* st, address pc, int unitsize) {
+  st->print_cr("Instructions: (pc=" PTR_FORMAT ")", p2i(pc));
+  print_hex_dump(st, pc - 256, pc + 256, unitsize);
+}
 // Fill in buffer with current local time as an ISO-8601 string.
 // E.g., yyyy-mm-ddThh:mm:ss-zzzz.
 // Returns buffer, or NULL if it failed.

--- a/hotspot/src/share/vm/runtime/sharedRuntime.hpp
+++ b/hotspot/src/share/vm/runtime/sharedRuntime.hpp
@@ -33,6 +33,7 @@
 #include "runtime/threadLocalStorage.hpp"
 #include "utilities/hashtable.hpp"
 #include "utilities/macros.hpp"
+#include "runtime/thread.hpp"
 
 class AdapterHandlerEntry;
 class AdapterHandlerTable;
@@ -197,6 +198,7 @@ class SharedRuntime: AllStatic {
   static void    throw_NullPointerException_at_call(JavaThread* thread);
   static void    throw_StackOverflowError(JavaThread* thread);
   static void    throw_delayed_StackOverflowError(JavaThread* thread);
+  static void    throw_StackOverflowError_common(JavaThread* thread, bool delayed);
   static address continuation_for_implicit_exception(JavaThread* thread,
                                                      address faulting_pc,
                                                      ImplicitExceptionKind exception_kind);
@@ -397,13 +399,13 @@ class SharedRuntime: AllStatic {
                               const BasicType *sig_bt,
                               const VMRegPair *regs);
 
-  static nmethod* generate_native_wrapper(MacroAssembler* masm,
+  /*static nmethod* generate_native_wrapper(MacroAssembler* masm,
                                           const methodHandle& method,
                                           int compile_id,
                                           BasicType* sig_bt,
                                           VMRegPair* regs,
                                           BasicType ret_type,
-                                          address critical_entry);
+                                          address critical_entry);*/
   // Generate I2C and C2I adapters. These adapters are simple argument marshalling
   // blobs. Unlike adapters in the tiger and earlier releases the code in these
   // blobs does not create a new frame and are therefore virtually invisible

--- a/hotspot/src/share/vm/runtime/thread.inline.hpp
+++ b/hotspot/src/share/vm/runtime/thread.inline.hpp
@@ -59,14 +59,18 @@ inline jlong Thread::cooked_allocated_bytes() {
   return allocated_bytes;
 }
 
-#if defined(PPC64) || defined (AARCH64)
-inline JavaThreadState JavaThread::thread_state() const    {
-  return (JavaThreadState) OrderAccess::load_acquire((volatile jint*)&_thread_state);
+inline bool JavaThread::stack_reserved_zone_disabled() {
+  return _stack_guard_state == stack_guard_reserved_disabled;
 }
 
-inline void JavaThread::set_thread_state(JavaThreadState s) {
+#if defined(PPC64) || defined (AARCH64)  || defined (RISCV64)
+//inline JavaThreadState JavaThread::thread_state() const    {
+  //return (JavaThreadState) OrderAccess::load_acquire((volatile jint*)&_thread_state);
+//}
+
+/*inline void JavaThread::set_thread_state(JavaThreadState s) {
   OrderAccess::release_store((volatile jint*)&_thread_state, (jint)s);
-}
+}*/
 #endif
 
 inline void JavaThread::set_done_attaching_via_jni() {

--- a/hotspot/src/share/vm/runtime/vm_version.cpp
+++ b/hotspot/src/share/vm/runtime/vm_version.cpp
@@ -83,6 +83,9 @@ int Abstract_VM_Version::_vm_build_number = 0;
 bool Abstract_VM_Version::_initialized = false;
 int Abstract_VM_Version::_parallel_worker_threads = 0;
 bool Abstract_VM_Version::_parallel_worker_threads_initialized = false;
+const char* Abstract_VM_Version::_features_string = "";
+const char* VM_Version::_features_str;
+
 
 void Abstract_VM_Version::initialize() {
   if (_initialized) {


### PR DESCRIPTION
From jdk11 to jdk8, the definition and declaration of these functions are missing in JDK8.This results in an "undefined symbol" error.