### PR TITLE
Delete wrong include to fix macro error

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/globals_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/globals_riscv64.hpp
@@ -29,7 +29,7 @@
 
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include "memory/allocation.hpp"
+//#include "memory/allocation.hpp"
 
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)


### PR DESCRIPTION
Delete wrong include to fix macro error