### PR TITLE
Fix stack_shadow_zone_size

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.cpp
@@ -1676,7 +1676,8 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
   // was post-decremented.)  Skip this address by starting at i=1, and
   // touch a few more pages below.  N.B.  It is important to touch all
   // the way down to and including i=StackShadowPages.
-  for (int i = 0; i < (int)(JavaThread::stack_shadow_zone_size() / os::vm_page_size()) - 1; i++) {
+  //for (int i = 0; i < (int)(JavaThread::stack_shadow_zone_size() / os::vm_page_size()) - 1; i++) {
+    for (int i = 0; i< StackShadowPages-1; i++) {
     // this could be any sized move but this is can be a debugging crumb
     // so the bigger the better.
     sub(tmp, tmp, os::vm_page_size());

--- a/hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/sharedRuntime_riscv64.cpp
@@ -1431,7 +1431,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Generate stack overflow check
   if (UseStackBanging) {
-    __ bang_stack_with_offset(JavaThread::stack_shadow_zone_size());
+   //__ bang_stack_with_offset(JavaThread::stack_shadow_zone_size());
+    __ bang_stack_with_offset(StackShadowPages*os::vm_page_size());
   } else {
     Unimplemented();
   }

--- a/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/templateInterpreterGenerator_riscv64.cpp
@@ -1002,10 +1002,11 @@ void InterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   // an interpreter frame with greater than a page of locals, so each page
   // needs to be checked.  Only true for non-native.
   if (UseStackBanging) {
-    const int n_shadow_pages = JavaThread::stack_shadow_zone_size() / os::vm_page_size();
-    const int start_page = native_call ? n_shadow_pages : 1;
-    const int page_size = os::vm_page_size();
-    for (int pages = start_page; pages <= n_shadow_pages ; pages++) {
+   // const int n_shadow_pages = JavaThread::stack_shadow_zone_size() / os::vm_page_size();
+   // const int start_page = native_call ? n_shadow_pages : 1;
+   const int start_page = native_call ? StackShadowPages : 1;
+   const int page_size = os::vm_page_size();
+     for (int pages = start_page; pages <= StackShadowPages ; pages++) {
       __ sub(t1, sp, pages * page_size);
       __ sd(zr, Address(t1));
     }


### PR DESCRIPTION
Because there is no JavaThread::stack_shadow_zone_size()  in JDK8, and use StackShadowPages instead of it.