### PR TITLE
Fix load_resolved_reference_at_index to solve obj->oop()

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
@@ -272,7 +272,7 @@ void InterpreterMacroAssembler::get_cache_entry_pointer_at_bcp(Register cache,
 }
 
 // Load object from cpool->resolved_references(index)
-void InterpreterMacroAssembler::load_resolved_reference_at_index(
+/*void InterpreterMacroAssembler::load_resolved_reference_at_index(
                                 Register result, Register index, Register tmp) {
   assert_different_registers(result, index);
 
@@ -287,7 +287,23 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(
   add(result, result, index);
  // load_heap_oop(result, Address(result, 0));
  load_heap_oop_rv(result, Address(result, arrayOopDesc::base_offset_in_bytes(T_OBJECT)));
+}*/
+void InterpreterMacroAssembler::load_resolved_reference_at_index(
+                                Register result, Register index, Register tmp) {
+  assert_different_registers(result, index);
+
+  get_constant_pool(result);
+  // load pointer for resolved_references[] objArray
+ // ld(result, Address(result, ConstantPool::cache_offset_in_bytes()));
+  ld(result, Address(result, ConstantPool::resolved_references_offset_in_bytes()));
+  resolve_oop_handle(result, tmp);
+  // Add in the index
+  addi(index, index, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
+  slli(index, index, LogBytesPerHeapOop);
+  add(result, result, index);
+  load_heap_oop(result, Address(result, 0));
 }
+
 
 void InterpreterMacroAssembler::load_resolved_klass_at_offset(
                                 Register cpool, Register index, Register klass, Register temp) {


### PR DESCRIPTION
Fix the error 
```
#  Internal Error (/home/zhangxiang/rv-jdk8u/jdk8u/hotspot/src/share/vm/runtime/handles.cpp:50), pid=1094596, tid=0x00000040037561e0
#  assert(obj->is_oop()) failed: not an oop: 0x00000000f1f1f1f1
```