### PR TITLE
Fix c1_LIR.hpp

### DIFF
--- a/hotspot/src/share/vm/c1/c1_LIR.hpp
+++ b/hotspot/src/share/vm/c1/c1_LIR.hpp
@@ -542,7 +542,7 @@ class LIR_Address: public LIR_OprPtr {
      , _type(type)
      , _disp(0) { verify(); }
 
-#if defined(X86) || defined(ARM) || defined(AARCH64)
+#if defined(X86) || defined(ARM) || defined(AARCH64) || defined(RISCV64)
   LIR_Address(LIR_Opr base, LIR_Opr index, Scale scale, intx disp, BasicType type):
        _base(base)
      , _index(index)
@@ -563,13 +563,13 @@ class LIR_Address: public LIR_OprPtr {
   virtual void print_value_on(outputStream* out) const PRODUCT_RETURN;
 
   void verify0() const PRODUCT_RETURN;
+  void verify_rv() const PRODUCT_RETURN;
 #if defined(LIR_ADDRESS_PD_VERIFY) && !defined(PRODUCT)
   void pd_verify() const;
   void verify() const { pd_verify(); }
 #else
   void verify() const { verify0(); }
-#endif
-
+#endif 
   static Scale scale(BasicType type);
 };
 
@@ -626,12 +626,12 @@ class LIR_OprFact: public AllStatic {
                                                                              LIR_OprDesc::fpu_register         |
                                                                              LIR_OprDesc::double_size); }
 #elif defined(X86) || defined(AARCH64) || defined(RISCV64)
+
   static LIR_Opr double_fpu(int reg)            { return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
                                                                              (reg  << LIR_OprDesc::reg2_shift) |
                                                                              LIR_OprDesc::double_type          |
                                                                              LIR_OprDesc::fpu_register         |
                                                                              LIR_OprDesc::double_size); }
-
   static LIR_Opr single_xmm(int reg)            { return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
                                                                              LIR_OprDesc::float_type           |
                                                                              LIR_OprDesc::fpu_register         |
@@ -885,6 +885,7 @@ class    LIR_OpTypeCheck;
 class    LIR_OpCompareAndSwap;
 class    LIR_OpProfileCall;
 class    LIR_OpProfileType;
+NO_FLAGREG_ONLY(class    LIR_Op4;)
 #ifdef ASSERT
 class    LIR_OpAssert;
 #endif
@@ -1151,6 +1152,7 @@ class LIR_Op: public CompilationResourceObj {
   virtual LIR_OpCompareAndSwap* as_OpCompareAndSwap() { return NULL; }
   virtual LIR_OpProfileCall* as_OpProfileCall() { return NULL; }
   virtual LIR_OpProfileType* as_OpProfileType() { return NULL; }
+  NO_FLAGREG_ONLY(virtual LIR_Op4* as_Op4() { return NULL; })
 #ifdef ASSERT
   virtual LIR_OpAssert* as_OpAssert() { return NULL; }
 #endif
@@ -1421,7 +1423,7 @@ class LIR_OpRTCall: public LIR_OpCall {
   virtual void verify() const;
 };
 
-
+#ifndef NO_FLAG_REG
 class LIR_OpBranch: public LIR_Op {
  friend class LIR_OpVisitState;
 
@@ -1464,7 +1466,7 @@ class LIR_OpBranch: public LIR_Op {
   virtual LIR_OpBranch* as_OpBranch() { return this; }
   virtual void print_instr(outputStream* out) const PRODUCT_RETURN;
 };
-
+#endif
 
 class ConversionStub;
 
@@ -1474,7 +1476,7 @@ class LIR_OpConvert: public LIR_Op1 {
  private:
    Bytecodes::Code _bytecode;
    ConversionStub* _stub;
-#if defined(PPC) || defined(AARCH64)
+#if defined(PPC) || defined(AARCH64) || defined(RISCV64)
   LIR_Opr _tmp1;
   LIR_Opr _tmp2;
 #endif
@@ -1489,7 +1491,7 @@ class LIR_OpConvert: public LIR_Op1 {
 #endif
      , _bytecode(code)                           {}
 
-#if defined(PPC) || defined(AARCH64)
+#if defined(PPC) || defined(AARCH64) || defined(RISCV64)
    LIR_OpConvert(Bytecodes::Code code, LIR_Opr opr, LIR_Opr result, ConversionStub* stub
                  ,LIR_Opr tmp1, LIR_Opr tmp2)
      : LIR_Op1(lir_convert, opr, result)
@@ -1501,7 +1503,7 @@ class LIR_OpConvert: public LIR_Op1 {
 
   Bytecodes::Code bytecode() const               { return _bytecode; }
   ConversionStub* stub() const                   { return _stub; }
-#if defined(PPC) || defined(AARCH64)
+#if defined(PPC) || defined(AARCH64) || defined(RISCV64)
   LIR_Opr tmp1() const                           { return _tmp1; }
   LIR_Opr tmp2() const                           { return _tmp2; }
 #endif
@@ -1512,7 +1514,6 @@ class LIR_OpConvert: public LIR_Op1 {
 
   static void print_bytecode(outputStream* out, Bytecodes::Code code) PRODUCT_RETURN;
 };
-
 
 // LIR_OpAllocObj
 class LIR_OpAllocObj : public LIR_Op1 {
@@ -1647,6 +1648,7 @@ class LIR_Op2: public LIR_Op {
   void verify() const;
 
  public:
+#ifndef NO_FLAG_REG
   LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, CodeEmitInfo* info = NULL)
     : LIR_Op(code, LIR_OprFact::illegalOpr, info)
     , _opr1(opr1)
@@ -1677,6 +1679,22 @@ class LIR_Op2: public LIR_Op {
     assert(code == lir_cmove, "code check");
     assert(type != T_ILLEGAL, "cmove should have type");
   }
+#else
+  LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
+          CodeEmitInfo* info = NULL, BasicType type = T_ILLEGAL)
+    : LIR_Op(code, LIR_OprFact::illegalOpr, info)
+    , _opr1(opr1)
+    , _opr2(opr2)
+    , _type(type)
+    , _condition(condition)
+    , _tmp1(LIR_OprFact::illegalOpr)
+    , _tmp2(LIR_OprFact::illegalOpr)
+    , _tmp3(LIR_OprFact::illegalOpr)
+    , _tmp4(LIR_OprFact::illegalOpr)
+    , _tmp5(LIR_OprFact::illegalOpr) {
+    assert(code == lir_assert || code == lir_branch || code == lir_cond_float_branch, "code check");
+  }
+#endif
 
   LIR_Op2(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result = LIR_OprFact::illegalOpr,
           CodeEmitInfo* info = NULL, BasicType type = T_ILLEGAL)
@@ -1691,7 +1709,12 @@ class LIR_Op2: public LIR_Op {
     , _tmp3(LIR_OprFact::illegalOpr)
     , _tmp4(LIR_OprFact::illegalOpr)
     , _tmp5(LIR_OprFact::illegalOpr) {
+#ifndef NO_FLAG_REG
     assert(code != lir_cmp && is_in_range(code, begin_op2, end_op2), "code check");
+#else
+    assert((code != lir_branch && code != lir_cond_float_branch)
+           && is_in_range(code, begin_op2, end_op2), "code check");
+#endif
   }
 
   LIR_Op2(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result, LIR_Opr tmp1, LIR_Opr tmp2 = LIR_OprFact::illegalOpr,
@@ -1707,7 +1730,12 @@ class LIR_Op2: public LIR_Op {
     , _tmp3(tmp3)
     , _tmp4(tmp4)
     , _tmp5(tmp5) {
+#ifndef NO_FLAG_REG
     assert(code != lir_cmp && is_in_range(code, begin_op2, end_op2), "code check");
+#else
+    assert((code != lir_branch && code != lir_cond_float_branch)
+           && is_in_range(code, begin_op2, end_op2), "code check");
+#endif
   }
 
   LIR_Opr in_opr1() const                        { return _opr1; }
@@ -1719,10 +1747,20 @@ class LIR_Op2: public LIR_Op {
   LIR_Opr tmp4_opr() const                       { return _tmp4; }
   LIR_Opr tmp5_opr() const                       { return _tmp5; }
   LIR_Condition condition() const  {
-    assert(code() == lir_cmp || code() == lir_cmove || code() == lir_assert, "only valid for cmp and cmove and assert"); return _condition;
+#ifndef NO_FLAG_REG
+    assert(code() == lir_cmp || code() == lir_cmove || code() == lir_assert, "only valid for cmp and cmove and assert");
+#else
+    assert(code() == lir_branch || code() == lir_cond_float_branch || code() == lir_assert, "only valid for branch and assert");
+#endif
+    return _condition;
   }
   void set_condition(LIR_Condition condition) {
-    assert(code() == lir_cmp || code() == lir_cmove, "only valid for cmp and cmove");  _condition = condition;
+#ifndef NO_FLAG_REG
+    assert(code() == lir_cmp || code() == lir_cmove, "only valid for cmp and cmove");
+#else
+    assert(code() == lir_branch || code() == lir_cond_float_branch, "only valid for branch");
+#endif
+    _condition = condition;
   }
 
   void set_fpu_stack_size(int size)              { _fpu_stack_size = size; }
@@ -1736,6 +1774,58 @@ class LIR_Op2: public LIR_Op {
   virtual void print_instr(outputStream* out) const PRODUCT_RETURN;
 };
 
+//#if defined(RISCV64)
+#ifdef NO_FLAG_REG
+// LIR_OpBranch
+class LIR_OpBranch: public LIR_Op2 {
+ friend class LIR_OpVisitState;
+
+ private:
+  Label*        _label;
+  BlockBegin*   _block;  // if this is a branch to a block, this is the block
+  BlockBegin*   _ublock; // if this is a float-branch, this is the unorderd block
+  CodeStub*     _stub;   // if this is a branch to a stub, this is the stub
+  LIR_Condition _cond;
+  BasicType     _type;
+
+
+
+ public:
+   // these are temporary constructors until we start using the conditional register
+   LIR_OpBranch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, Label* lbl)
+     :  LIR_Op2(lir_branch, cond, left, right,  (CodeEmitInfo*)(NULL))
+      , _label(lbl), _block(NULL), _ublock(NULL), _stub(NULL) { }
+
+  //LIR_OpBranch(LIR_Condition cond, BasicType type, BlockBegin* block);
+ // LIR_OpBranch(LIR_Condition cond, BasicType type, CodeStub* stub);
+ // LIR_OpBranch(LIR_Condition cond, BasicType type,  Label* lbl);
+  // for unordered comparisons
+  //LIR_OpBranch(LIR_Condition cond, BasicType type, BlockBegin* block, BlockBegin* ublock);
+  LIR_OpBranch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, BlockBegin* block);
+
+   LIR_OpBranch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, CodeStub* stub);
+
+   // for unordered comparisons
+   LIR_OpBranch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, BlockBegin *block,
+    BlockBegin *ublock);
+
+  LIR_Condition cond()        const              { return condition();  }
+  LIR_Opr       left()        const              { return in_opr1();    }
+  LIR_Opr       right()       const              { return in_opr2();    }
+  Label*        label()       const              { return _label;       }
+  BlockBegin*   block()       const              { return _block;       }
+  BlockBegin*   ublock()      const              { return _ublock;      }
+  CodeStub*     stub()        const              { return _stub;        }
+
+  void          change_block(BlockBegin* b);
+  void          change_ublock(BlockBegin* b);
+  void          negate_cond();
+
+  virtual void emit_code(LIR_Assembler* masm);
+  virtual LIR_OpBranch* as_OpBranch() { return this; }
+  virtual void print_instr(outputStream* out) const PRODUCT_RETURN;
+};
+#endif
 class LIR_OpAllocArray : public LIR_Op {
  friend class LIR_OpVisitState;
 
@@ -1796,6 +1886,63 @@ class LIR_Op3: public LIR_Op {
 
   virtual void emit_code(LIR_Assembler* masm);
   virtual LIR_Op3* as_Op3() { return this; }
+  virtual void print_instr(outputStream* out) const PRODUCT_RETURN;
+};
+
+
+class LIR_Op4: public LIR_Op {
+  friend class LIR_OpVisitState;
+ protected:
+  LIR_Opr   _opr1;
+  LIR_Opr   _opr2;
+  LIR_Opr   _opr3;
+  LIR_Opr   _opr4;
+  BasicType _type;
+  LIR_Opr   _tmp1;
+  LIR_Opr   _tmp2;
+  LIR_Opr   _tmp3;
+  LIR_Opr   _tmp4;
+  LIR_Opr   _tmp5;
+  LIR_Condition _condition;
+
+ public:
+  LIR_Op4(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr opr3, LIR_Opr opr4,
+          LIR_Opr result, BasicType type)
+    : LIR_Op(code, result, NULL)
+    , _opr1(opr1)
+    , _opr2(opr2)
+    , _opr3(opr3)
+    , _opr4(opr4)
+    , _type(type)
+    , _condition(condition)
+    , _tmp1(LIR_OprFact::illegalOpr)
+    , _tmp2(LIR_OprFact::illegalOpr)
+    , _tmp3(LIR_OprFact::illegalOpr)
+    , _tmp4(LIR_OprFact::illegalOpr)
+    , _tmp5(LIR_OprFact::illegalOpr) {
+    assert(code == lir_cmove, "code check");
+    assert(type != T_ILLEGAL, "cmove should have type");
+  }
+
+  LIR_Opr in_opr1() const                        { return _opr1; }
+  LIR_Opr in_opr2() const                        { return _opr2; }
+  LIR_Opr in_opr3() const                        { return _opr3; }
+  LIR_Opr in_opr4() const                        { return _opr4; }
+  BasicType type()  const                        { return _type; }
+  LIR_Opr tmp1_opr() const                       { return _tmp1; }
+  LIR_Opr tmp2_opr() const                       { return _tmp2; }
+  LIR_Opr tmp3_opr() const                       { return _tmp3; }
+  LIR_Opr tmp4_opr() const                       { return _tmp4; }
+  LIR_Opr tmp5_opr() const                       { return _tmp5; }
+  LIR_Condition cond() const                     { return _condition; }
+
+  void set_in_opr1(LIR_Opr opr)                  { _opr1 = opr; }
+  void set_in_opr2(LIR_Opr opr)                  { _opr2 = opr; }
+  void set_in_opr3(LIR_Opr opr)                  { _opr3 = opr; }
+  void set_in_opr4(LIR_Opr opr)                  { _opr4 = opr; }
+  virtual void emit_code(LIR_Assembler* masm);
+  virtual LIR_Op4* as_Op4() { return this; }
+
   virtual void print_instr(outputStream* out) const PRODUCT_RETURN;
 };
 
@@ -2176,19 +2323,28 @@ class LIR_List: public CompilationResourceObj {
   void pop(LIR_Opr reg)                                    { append(new LIR_Op1(lir_pop,  reg)); }
 
   void cmp(LIR_Condition condition, LIR_Opr left, LIR_Opr right, CodeEmitInfo* info = NULL) {
+#ifndef NO_FLAG_REG
     append(new LIR_Op2(lir_cmp, condition, left, right, info));
+#endif
   }
   void cmp(LIR_Condition condition, LIR_Opr left, int right, CodeEmitInfo* info = NULL) {
+#ifndef NO_FLAG_REG
     cmp(condition, left, LIR_OprFact::intConst(right), info);
+#endif
   }
-
+#ifndef NO_FLAG_REG
   void cmp_mem_int(LIR_Condition condition, LIR_Opr base, int disp, int c, CodeEmitInfo* info);
   void cmp_reg_mem(LIR_Condition condition, LIR_Opr reg, LIR_Address* addr, CodeEmitInfo* info);
 
   void cmove(LIR_Condition condition, LIR_Opr src1, LIR_Opr src2, LIR_Opr dst, BasicType type) {
     append(new LIR_Op2(lir_cmove, condition, src1, src2, dst, type));
   }
-
+#else
+  void cmove(LIR_Condition condition, LIR_Opr cmp1, LIR_Opr cmp2, LIR_Opr src1, LIR_Opr src2, LIR_Opr dst,
+    BasicType type) {
+    append(new LIR_Op4(lir_cmove, condition, cmp1, cmp2, src1, src2, dst, type));
+  }
+#endif
   void cas_long(LIR_Opr addr, LIR_Opr cmp_value, LIR_Opr new_value,
                 LIR_Opr t1, LIR_Opr t2, LIR_Opr result = LIR_OprFact::illegalOpr);
   void cas_obj(LIR_Opr addr, LIR_Opr cmp_value, LIR_Opr new_value,
@@ -2236,7 +2392,7 @@ class LIR_List: public CompilationResourceObj {
   void allocate_array(LIR_Opr dst, LIR_Opr len, LIR_Opr t1,LIR_Opr t2, LIR_Opr t3,LIR_Opr t4, BasicType type, LIR_Opr klass, CodeStub* stub);
 
   // jump is an unconditional branch
-  void jump(BlockBegin* block) {
+/*  void jump(BlockBegin* block) {
     append(new LIR_OpBranch(lir_cond_always, T_ILLEGAL, block));
   }
   void jump(CodeStub* stub) {
@@ -2255,7 +2411,45 @@ class LIR_List: public CompilationResourceObj {
     assert(type == T_FLOAT || type == T_DOUBLE, "fp comparisons only");
     append(new LIR_OpBranch(cond, type, block, unordered));
   }
+*/
 
+  void jump(BlockBegin* block) {
+    append(new LIR_OpBranch(lir_cond_always, NO_FLAGREG_ONLY_ARG(LIR_OprFact::illegalOpr)
+                            NO_FLAGREG_ONLY_ARG(LIR_OprFact::illegalOpr) T_ILLEGAL, block));
+  }
+  void jump(CodeStub* stub) {
+    append(new LIR_OpBranch(lir_cond_always, NO_FLAGREG_ONLY_ARG(LIR_OprFact::illegalOpr)
+                            NO_FLAGREG_ONLY_ARG(LIR_OprFact::illegalOpr) T_ILLEGAL, stub));
+  }
+#ifndef NO_FLAG_REG
+  void branch(LIR_Condition cond, BasicType type, Label* lbl)        { append(new LIR_OpBranch(cond, type, lbl)); }
+  void branch(LIR_Condition cond, BasicType type, BlockBegin* block) {
+    assert(type != T_FLOAT && type != T_DOUBLE, "no fp comparisons");
+    append(new LIR_OpBranch(cond, type, block));
+  }
+  void branch(LIR_Condition cond, BasicType type, CodeStub* stub)    {
+    assert(type != T_FLOAT && type != T_DOUBLE, "no fp comparisons");
+    append(new LIR_OpBranch(cond, type, stub));
+  }
+  void branch(LIR_Condition cond, BasicType type, BlockBegin* block, BlockBegin* unordered) {
+    assert(type == T_FLOAT || type == T_DOUBLE, "fp comparisons only");
+    append(new LIR_OpBranch(cond, type, block, unordered));
+  }
+#else
+  void branch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, Label* lbl) {
+    append(new LIR_OpBranch(cond, left, right, type, lbl));
+  }
+  void branch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, BlockBegin* block) {
+    append(new LIR_OpBranch(cond, left, right, type, block));
+  }
+  void branch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type, CodeStub* stub) {
+    append(new LIR_OpBranch(cond, left, right, type, stub));
+  }
+  void branch(LIR_Condition cond, LIR_Opr left, LIR_Opr right, BasicType type,
+    BlockBegin* block, BlockBegin* unordered) {
+    append(new LIR_OpBranch(cond, left, right, type, block, unordered));
+  }
+#endif
   void shift_left(LIR_Opr value, LIR_Opr count, LIR_Opr dst, LIR_Opr tmp);
   void shift_right(LIR_Opr value, LIR_Opr count, LIR_Opr dst, LIR_Opr tmp);
   void unsigned_shift_right(LIR_Opr value, LIR_Opr count, LIR_Opr dst, LIR_Opr tmp);


### PR DESCRIPTION
Fix LIR_Op4 for adding NO_FLAGREG_ONLY;
Fix LIR_Op4* as_Op4()  for adding NO_FLAGREG_ONLY;
Fix LIR_Op2  for adding NO_FLAGREG_ONLY;
Fix class LIR_OpBranch: public LIR_Op2 for adding NO_FLAG_REG;

Fix  class LIR_Op4: public LIR_Op for adding NO_FLAG_REG;
Fix branch/cmove/cmp for adding NO_FLAG_REG;