### PR TITLE
Using InterpreterProfileLimit instead of InterpreterBackwardBranchLimit

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/templateTable_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/templateTable_riscv64.cpp
@@ -2041,7 +2041,7 @@ void TemplateTable::branch(bool is_jsr, bool is_wide)
       if (ProfileInterpreter) {
         // Test to see if we should create a method data oop
         //__ lwu(t0, Address(t1, in_bytes(MethodCounters::interpreter_profile_limit_offset())));
-        __ la(t0, ExternalAddress((address) &InvocationCounter::InterpreterBackwardBranchLimit)); 
+        __ la(t0, ExternalAddress((address) &InvocationCounter::InterpreterProfileLimit)); 
         __ blt(x10, t0, dispatch);
 
         // if no method data exists, go to profile method


### PR DESCRIPTION
There is no InterpreterBackwardBranchLimit in JDK8, so Using InterpreterProfileLimit instead of InterpreterBackwardBranchLimit.