### PR TITLE
Add HAS_FLAGREG_ONLY in LIR_Op2::verify() for rv64 support

### DIFF
--- a/hotspot/src/share/vm/c1/c1_LIR.cpp
+++ b/hotspot/src/share/vm/c1/c1_LIR.cpp
@@ -299,7 +299,7 @@ bool LIR_OprDesc::is_oop() const {
 void LIR_Op2::verify() const {
 #ifdef ASSERT
   switch (code()) {
-    case lir_cmove:
+    HAS_FLAGREG_ONLY(case lir_cmove:)
     case lir_xchg:
       break;
 


### PR DESCRIPTION
Add HAS_FLAGREG_ONLY in LIR_Op2::verify() for rv64 support