### PR TITLE
debug.cpp help() is missing a riscv64 line for pns

### DIFF
--- a/hotspot/src/share/vm/utilities/debug.cpp
+++ b/hotspot/src/share/vm/utilities/debug.cpp
@@ -689,6 +689,7 @@ void help() {
   tty->print_cr("                   pns($sp, $rbp, $pc) on Linux/amd64 and Solaris/amd64 or");
   tty->print_cr("                   pns($sp, $ebp, $pc) on Linux/x86 or");
   tty->print_cr("                   pns($sp, $fp, $pc)  on Linux/AArch64 or");
+  tty->print_cr("                   pns($sp, $fp, $pc)  on Linux/riscv64 or");
   tty->print_cr("                   pns($sp, 0, $pc)    on Linux/ppc64 or");
   tty->print_cr("                   pns($sp + 0x7ff, 0, $pc) on Solaris/SPARC");
   tty->print_cr("                 - in gdb do 'set overload-resolution off' before calling pns()");


### PR DESCRIPTION
debug.cpp help() is missing a riscv64 line for pns