### PR TITLE
Fix vframeArray::fill_in by adding support for riscv64

### DIFF
--- a/hotspot/src/share/vm/runtime/vframeArray.cpp
+++ b/hotspot/src/share/vm/runtime/vframeArray.cpp
@@ -477,7 +477,7 @@ void vframeArray::fill_in(JavaThread* thread,
   // Copy registers for callee-saved registers
   if (reg_map != NULL) {
     for(int i = 0; i < RegisterMap::reg_count; i++) {
-#if defined(AMD64) || defined(AARCH64) 
+#if defined(AMD64) || defined(AARCH64) || defined(RISCV64)
       // The register map has one entry for every int (32-bit value), so
       // 64-bit physical registers have two entries in the map, one for
       // each half.  Ignore the high halves of 64-bit registers, just like


### PR DESCRIPTION
Fix vframeArray::fill_in by adding support for riscv64