### PR TITLE
Fix load_heap_oop_rv/do_oop_store_rv/load_unsigned_byte

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/templateTable_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/templateTable_riscv64.cpp
@@ -1973,7 +1973,7 @@ void TemplateTable::branch(bool is_jsr, bool is_wide)
     __ push_i(x11);
     // Adjust the bcp by the 16-bit displacement in x12
     __ add(xbcp, xbcp, x12);
-    //__ load_unsigned_byte(t0, Address(xbcp, 0));
+    __ load_unsigned_byte(t0, Address(xbcp, 0));
     // load the next target bytecode into t0, it is the argument of dispatch_only
     __ dispatch_only(vtos, /*generate_poll*/true);
     return;


### PR DESCRIPTION
Fix load_heap_oop_rv/do_oop_store_rv due to barrierset in jdk11 is defferent from jdk8.

Add load_unsigned_byte, because load the next target bytecode into t0, it is the argument of dispatch_only.