### PR TITLE
Fix interpreterRT_riscv64.hpp/interpreterRT_riscv64.cpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/interpreterRT_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/interpreterRT_riscv64.cpp
@@ -48,7 +48,7 @@ Register InterpreterRuntime::SignatureHandlerGenerator::to()   { return sp; }
 Register InterpreterRuntime::SignatureHandlerGenerator::temp() { return t0; }
 
 InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator(
-  const methodHandle& method, CodeBuffer* buffer) : NativeSignatureIterator(method) {
+   methodHandle method, CodeBuffer* buffer) : NativeSignatureIterator(method) {
   _masm = new MacroAssembler(buffer); // allocate on resourse area by default
   _num_int_args = (method->is_static() ? 1 : 0);
   _num_fp_args = 0;
@@ -256,7 +256,7 @@ class SlowSignatureHandler
   }
 
  public:
-  SlowSignatureHandler(const methodHandle& method, address from, intptr_t* to)
+  SlowSignatureHandler(const methodHandle method, address from, intptr_t* to)
     : NativeSignatureIterator(method)
   {
     _from = from;

--- a/hotspot/src/cpu/riscv64/vm/interpreterRT_riscv64.hpp
+++ b/hotspot/src/cpu/riscv64/vm/interpreterRT_riscv64.hpp
@@ -26,6 +26,7 @@
 
 #ifndef CPU_RISCV64_VM_INTERPRETERRT_RISCV64_HPP
 #define CPU_RISCV64_VM_INTERPRETERRT_RISCV64_HPP
+#include "memory/allocation.hpp"
 
 // This is included in the middle of class Interpreter.
 // Do not include files here.
@@ -47,7 +48,7 @@ class SignatureHandlerGenerator: public NativeSignatureIterator {
 
  public:
   // Creation
-  SignatureHandlerGenerator(const methodHandle& method, CodeBuffer* buffer);
+  SignatureHandlerGenerator(methodHandle method, CodeBuffer* buffer);
   virtual ~SignatureHandlerGenerator() {
     _masm = NULL;
   }


### PR DESCRIPTION
Fix the args of  SignatureHandlerGenerator(delete const/&)
Add #include "memory/allocation.hpp"
