### PR TITLE
Add support for riscv64 in libproc.h

### DIFF
--- a/hotspot/agent/src/os/linux/libproc.h
+++ b/hotspot/agent/src/os/linux/libproc.h
@@ -79,7 +79,7 @@ combination of ptrace and /proc calls.
 #include <asm/ptrace.h>
 #define user_regs_struct  pt_regs
 #endif
-#if defined(aarch64)
+#if defined(aarch64) || defined(RISCV64)
 #define user_regs_struct user_pt_regs
 #endif
 


### PR DESCRIPTION
Add support for riscv64 in libproc.h