### PR TITLE
Fix generate_method_handle_interpreter_entry by replacing lhu with lbu

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/methodHandles_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/methodHandles_riscv64.cpp
@@ -197,7 +197,7 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
 
     Label L;
     BLOCK_COMMENT("verify_intrinsic_id {");
-    __ lhu(t0, Address(xmethod, Method::intrinsic_id_offset_in_bytes()));
+    __ lbu(t0, Address(xmethod, Method::intrinsic_id_offset_in_bytes()));
     __ mv(t1, (int) iid);
     __ beq(t0, t1, L);
     if (iid == vmIntrinsics::_linkToVirtual ||


### PR DESCRIPTION
Fix generate_method_handle_interpreter_entry by replacing lhu with lbu.