### PR TITLE
Fix a typo about icache_riscv64.cpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/icache_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/icache_riscv64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "code/codeBlob.hpp"
 #include "runtime/icache.hpp"
 
 extern "C" void test_assembler_entry(CodeBuffer*);


### PR DESCRIPTION
Fix a typo about  include in icache_riscv64.cpp