### PR TITLE
Fix include by replacing intrinsicnode.hpp with memnode.hpp

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/macroAssembler_riscv64.cpp
@@ -47,7 +47,7 @@
 //#include "safepointMechanism_riscv64.hpp"
 #ifdef COMPILER2
 #include "opto/compile.hpp"
-//#include "opto/intrinsicnode.hpp"
+#include "opto/memnode.hpp"
 #include "opto/subnode.hpp"
 #include "opto/node.hpp"
 #endif


### PR DESCRIPTION
Fix include by replacing intrinsicnode.hpp with memnode.hpp