### PR TITLE
Fix vmIntrinsics::_linkToVirtual

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/methodHandles_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/methodHandles_riscv64.cpp
@@ -367,7 +367,7 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
 
       // pick out the vtable index from the MemberName, and then we can discard it:
       Register temp2_index = temp2;
-      __ access_load_at(T_ADDRESS, IN_HEAP, temp2_index, member_vmindex, noreg, noreg);
+      //__ access_load_at(T_ADDRESS, IN_HEAP, temp2_index, member_vmindex, noreg, noreg);
       //__ ld(temp2_index, member_vmindex);
       //__ access_load_at(T_ADDRESS, IN_HEAP, temp2_index, member_vmindex, noreg, noreg);
         __ ld(temp2_index, member_vmindex);


### PR DESCRIPTION
In fact,this is a type error.