### PR TITLE
Fix stack_guard_state_offset

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/templateInterpreter_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/templateInterpreter_riscv64.cpp
@@ -1636,7 +1636,7 @@ address InterpreterGenerator::generate_native_entry(bool synchronized) {
 
   {
     Label no_reguard;
-    __ lwu(t0, Address(xthread, in_bytes(JavaThread::stack_guard_state_offset())));
+    __ lbu(t0, Address(xthread, in_bytes(JavaThread::stack_guard_state_offset())));
     //__ addi(t1, zr, JavaThread::stack_guard_yellow_reserved_disabled);
     __ addi(t1, zr, JavaThread::stack_guard_yellow_disabled);
     __ bne(t0, t1, no_reguard);


### PR DESCRIPTION
Because the length of stack_guard_state_offset is one byte.