### PR TITLE
Fix lwu for form_address in c1

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/c1_LIRAssembler_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/c1_LIRAssembler_riscv64.cpp
@@ -1175,7 +1175,7 @@ void LIR_Assembler::profile_object(ciMethodData* md, ciProfileData* data, Regist
   __ mov_metadata(mdo, md->constant_encoding());
   Address data_addr = __ form_address(t1, mdo, md->byte_offset_of_slot(data, DataLayout::header_offset()));
   int header_bits = DataLayout::flag_mask_to_header_mask(BitData::null_seen_byte_constant());
-  __ lbu(t0, data_addr);
+  __ lwu(t0, data_addr);
   __ ori(t0, t0, header_bits);
   __ sb(t0, data_addr);
   __ j(*obj_is_null);


### PR DESCRIPTION
DataLayout::header_offset() is a union in JDK8 ,but it is a byte in JDK11