### PR TITLE
Fix profile_return_type due to intrinsic_id_offset_in_bytes

### DIFF
--- a/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
+++ b/hotspot/src/cpu/riscv64/vm/interp_masm_riscv64.cpp
@@ -1856,7 +1856,7 @@ void InterpreterMacroAssembler::profile_return_type(Register mdp, Register ret, 
       li(tmp, Bytecodes::_invokehandle);
       beq(t0, tmp, do_profile);
       get_method(tmp);
-      lhu(t0, Address(tmp, Method::intrinsic_id_offset_in_bytes()));
+      lbu(t0, Address(tmp, Method::intrinsic_id_offset_in_bytes()));
       li(t1, vmIntrinsics::_compiledLambdaForm);
       bne(t0, t1, profile_continue);
       bind(do_profile);


### PR DESCRIPTION
Because the length of intrinsic_id_offset_in_bytes is u1.And replace lhu with lbu.