### PR TITLE
Fixx for jtreg cachedSocket becauseof JDK-8169041

### DIFF
--- a/jdk/test/TEST.ROOT
+++ b/jdk/test/TEST.ROOT
@@ -18,7 +18,7 @@ keys=2d dnd i18n intermittent randomness headful jfr
 othervm.dirs=java/awt java/beans java/rmi javax/accessibility javax/imageio javax/sound javax/print javax/management com/sun/awt sun/awt sun/java2d sun/pisces sun/rmi
 
 # Tests that cannot run concurrently
-exclusiveAccess.dirs=java/rmi/Naming java/util/Currency java/util/prefs sun/management/jmxremote sun/tools/jstatd sun/security/mscapi javax/rmi
+exclusiveAccess.dirs=java/rmi/Naming java/util/Currency java/util/prefs sun/management/jmxremote sun/tools/jstatd sun/security/mscapi javax/rmi com/sun/corba/cachedSocket
 
 # Allow querying of sun.arch.data.model in @requires clauses
 requires.properties=sun.arch.data.model 


### PR DESCRIPTION
Fix failed com/sun/corba/cachedSocket/7056731.sh according to https://bugs.openjdk.org/browse/JDK-8169041 